### PR TITLE
Add the ElvisOperation to the new base language extensions

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -9807,6 +9807,21 @@
         <node concept="1E0d5M" id="vJfcQmbzfS" role="1E1XAP">
           <ref role="1E0d5P" node="vJfcQmbzfZ" resolve="de.itemis.mps.editor.pagination.runtime" />
         </node>
+        <node concept="1SiIV0" id="2o8W23R_vC7" role="3bR37C">
+          <node concept="3bR9La" id="2o8W23R_vC8" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2o8W23R_vCi" role="3bR37C">
+          <node concept="1Busua" id="2o8W23R_vCj" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2o8W23R_vCk" role="3bR37C">
+          <node concept="Rbm2T" id="2o8W23R_vCl" role="1SiIV1">
+            <ref role="1E1Vl2" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="vJfcQmbzfZ" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -22787,6 +22802,11 @@
             <node concept="3qWCbU" id="vJfcQmbGlG" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2o8W23R_v97" role="3bR37C">
+          <node concept="3bR9La" id="2o8W23R_v98" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
       </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/de.itemis.mps.baseLanguageExtensions.runtime.msd
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/de.itemis.mps.baseLanguageExtensions.runtime.msd
@@ -11,7 +11,12 @@
     </facet>
   </facets>
   <sourcePath />
-  <languageVersions />
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
   <dependencyVersions>
     <module reference="d91eaf6f-a378-467f-9524-0c201ee2e15f(de.itemis.mps.baseLanguageExtensions.runtime)" version="0" />
   </dependencyVersions>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/models/de.itemis.mps.baseLanguageExtensions.runtime.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/models/de.itemis.mps.baseLanguageExtensions.runtime.mps
@@ -1,8 +1,126 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:2eaed950-3bc1-47cd-9b02-e917ff994d7c(de.itemis.mps.baseLanguageExtensions.runtime)">
   <persistence version="9" />
-  <languages />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+  </languages>
   <imports />
-  <registry />
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ" />
+      <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
+        <child id="1109279881614" name="typeVariableDeclaration" index="16eVyc" />
+      </concept>
+      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="in" index="16syzq">
+        <reference id="1109283546497" name="typeVariableDeclaration" index="16sUi3" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+      </concept>
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="w6MstBXH_b">
+    <property role="TrG5h" value="ElvisOperationUtil" />
+    <node concept="2YIFZL" id="w6MstBXHAP" role="jymVt">
+      <property role="TrG5h" value="apply" />
+      <node concept="3clFbS" id="w6MstBXHAS" role="3clF47">
+        <node concept="3clFbJ" id="w6MstBXHFJ" role="3cqZAp">
+          <node concept="17QLQc" id="w6MstBXHNb" role="3clFbw">
+            <node concept="37vLTw" id="w6MstBXHGY" role="3uHU7B">
+              <ref role="3cqZAo" node="w6MstBXHCr" resolve="lhs" />
+            </node>
+            <node concept="10Nm6u" id="w6MstBXHMy" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="w6MstBXHFL" role="3clFbx">
+            <node concept="3cpWs6" id="w6MstBXHOy" role="3cqZAp">
+              <node concept="37vLTw" id="w6MstBXHQO" role="3cqZAk">
+                <ref role="3cqZAo" node="w6MstBXHCr" resolve="lhs" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="w6MstBXHSF" role="3cqZAp">
+          <node concept="2OqwBi" id="w6MstBXHVy" role="3cqZAk">
+            <node concept="37vLTw" id="w6MstBXHUi" role="2Oq$k0">
+              <ref role="3cqZAo" node="w6MstBXHDe" resolve="rhs" />
+            </node>
+            <node concept="1Bd96e" id="w6MstBXHY4" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="w6MstBXHAi" role="1B3o_S" />
+      <node concept="16syzq" id="w6MstBXHBZ" role="3clF45">
+        <ref role="16sUi3" node="w6MstBXHBl" resolve="T" />
+      </node>
+      <node concept="16euLQ" id="w6MstBXHBl" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+      <node concept="37vLTG" id="w6MstBXHCr" role="3clF46">
+        <property role="TrG5h" value="lhs" />
+        <node concept="16syzq" id="w6MstBXHCq" role="1tU5fm">
+          <ref role="16sUi3" node="w6MstBXHBl" resolve="T" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="w6MstBXHDe" role="3clF46">
+        <property role="TrG5h" value="rhs" />
+        <node concept="1ajhzC" id="w6MstBXHEb" role="1tU5fm">
+          <node concept="16syzq" id="w6MstBXHEB" role="1ajl9A">
+            <ref role="16sUi3" node="w6MstBXHBl" resolve="T" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="w6MstBXH_c" role="1B3o_S" />
+  </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/de.itemis.mps.baseLanguageExtensions.sandbox.msd
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/de.itemis.mps.baseLanguageExtensions.sandbox.msd
@@ -11,11 +11,17 @@
     </facet>
   </facets>
   <sourcePath />
+  <dependencies>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
   <languageVersions>
     <language slang="l:52b771c2-b79f-4f44-98f2-d24fd25a210b:de.itemis.mps.baseLanguageExtensions" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="46ef3165-951c-4ff0-9259-ca23b5717443(de.itemis.mps.baseLanguageExtensions.sandbox)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
@@ -3,8 +3,219 @@
   <persistence version="9" />
   <languages>
     <use id="52b771c2-b79f-4f44-98f2-d24fd25a210b" name="de.itemis.mps.baseLanguageExtensions" version="0" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="52b771c2-b79f-4f44-98f2-d24fd25a210b" name="de.itemis.mps.baseLanguageExtensions">
+      <concept id="578371460444482140" name="de.itemis.mps.baseLanguageExtensions.structure.ElvisOperation" flags="ng" index="1w0Eer" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="w6MstC1zab">
+    <property role="TrG5h" value="ElvisOperationSandbox" />
+    <node concept="2YIFZL" id="w6MstC1zl9" role="jymVt">
+      <property role="TrG5h" value="usage" />
+      <node concept="3clFbS" id="w6MstC1zlc" role="3clF47">
+        <node concept="3cpWs8" id="w6MstC1zih" role="3cqZAp">
+          <node concept="3cpWsn" id="w6MstC1zii" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="17QB3L" id="w6MstC1Nv0" role="1tU5fm" />
+            <node concept="1w0Eer" id="w6MstC1zbY" role="33vP2m">
+              <node concept="Xl_RD" id="w6MstC1zcA" role="3uHU7B">
+                <property role="Xl_RC" value="Hello" />
+              </node>
+              <node concept="Xl_RD" id="w6MstC1ze2" role="3uHU7w">
+                <property role="Xl_RC" value="World" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="w6MstC1D6s" role="3cqZAp">
+          <node concept="2OqwBi" id="w6MstC1DoF" role="3clFbG">
+            <node concept="10M0yZ" id="w6MstC1D79" role="2Oq$k0">
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+            </node>
+            <node concept="liA8E" id="w6MstC1DEY" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="37vLTw" id="w6MstC1DGs" role="37wK5m">
+                <ref role="3cqZAo" node="w6MstC1zii" resolve="result" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2o8W23RtbwG" role="3cqZAp">
+          <node concept="3cpWsn" id="2o8W23RtbwH" role="3cpWs9">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="2o8W23Rtbv6" role="1tU5fm" />
+            <node concept="1w0Eer" id="2o8W23Rtdy5" role="33vP2m">
+              <node concept="3cmrfG" id="2o8W23Rtue_" role="3uHU7w">
+                <property role="3cmrfH" value="4" />
+              </node>
+              <node concept="1eOMI4" id="2o8W23Rtuj_" role="3uHU7B">
+                <node concept="10QFUN" id="2o8W23Rtujy" role="1eOMHV">
+                  <node concept="3uibUv" id="2o8W23RtvC5" role="10QFUM">
+                    <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+                  </node>
+                  <node concept="10Nm6u" id="2o8W23RtuzG" role="10QFUP" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2o8W23RtbHi" role="3cqZAp">
+          <node concept="2OqwBi" id="2o8W23RtbHj" role="3clFbG">
+            <node concept="10M0yZ" id="2o8W23RtbHk" role="2Oq$k0">
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+            </node>
+            <node concept="liA8E" id="2o8W23RtbHl" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(int)" resolve="println" />
+              <node concept="37vLTw" id="2o8W23RtbHm" role="37wK5m">
+                <ref role="3cqZAo" node="2o8W23RtbwH" resolve="i" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2o8W23RtA1Z" role="3cqZAp">
+          <node concept="3cpWsn" id="2o8W23RtA20" role="3cpWs9">
+            <property role="TrG5h" value="j" />
+            <node concept="10Oyi0" id="2o8W23Rt_Pr" role="1tU5fm" />
+            <node concept="1w0Eer" id="2o8W23RtA21" role="33vP2m">
+              <node concept="3cmrfG" id="2o8W23RtA22" role="3uHU7w">
+                <property role="3cmrfH" value="5" />
+              </node>
+              <node concept="10Nm6u" id="2o8W23RtA23" role="3uHU7B" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2o8W23R_t67" role="3cqZAp">
+          <node concept="2OqwBi" id="2o8W23R_to1" role="3clFbG">
+            <node concept="10M0yZ" id="2o8W23R_t6h" role="2Oq$k0">
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+            </node>
+            <node concept="liA8E" id="2o8W23R_tC0" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(int)" resolve="println" />
+              <node concept="37vLTw" id="2o8W23R_tKD" role="37wK5m">
+                <ref role="3cqZAo" node="2o8W23RtA20" resolve="j" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2o8W23REpHu" role="3cqZAp">
+          <node concept="3cpWsn" id="2o8W23REpHv" role="3cpWs9">
+            <property role="TrG5h" value="different" />
+            <node concept="3uibUv" id="2o8W23REpHw" role="1tU5fm">
+              <ref role="3uigEE" to="guwi:~Serializable" resolve="Serializable" />
+            </node>
+            <node concept="1w0Eer" id="2o8W23REpHx" role="33vP2m">
+              <node concept="3cmrfG" id="2o8W23REpHy" role="3uHU7w">
+                <property role="3cmrfH" value="6" />
+              </node>
+              <node concept="Xl_RD" id="2o8W23REpHz" role="3uHU7B">
+                <property role="Xl_RC" value="Hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2o8W23REutH" role="3cqZAp">
+          <node concept="2OqwBi" id="2o8W23REuQ2" role="3clFbG">
+            <node concept="10M0yZ" id="2o8W23REuy2" role="2Oq$k0">
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+            </node>
+            <node concept="liA8E" id="2o8W23REvaP" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.Object)" resolve="println" />
+              <node concept="37vLTw" id="2o8W23REveQ" role="37wK5m">
+                <ref role="3cqZAo" node="2o8W23REpHv" resolve="desc" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="w6MstC1zkD" role="1B3o_S" />
+      <node concept="3cqZAl" id="w6MstC1zkZ" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="w6MstC1zac" role="1B3o_S" />
+  </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/de.itemis.mps.baseLanguageExtensions.mpl
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/de.itemis.mps.baseLanguageExtensions.mpl
@@ -50,12 +50,20 @@
         <module reference="52b771c2-b79f-4f44-98f2-d24fd25a210b(de.itemis.mps.baseLanguageExtensions)" version="0" />
         <module reference="0c2a16a3-4205-4401-a2b4-4af76e67fa52(de.itemis.mps.baseLanguageExtensions.generator)" version="0" />
         <module reference="d91eaf6f-a378-467f-9524-0c201ee2e15f(de.itemis.mps.baseLanguageExtensions.runtime)" version="0" />
+        <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+        <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+        <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
       </dependencyVersions>
       <mapping-priorities />
     </generator>
   </generators>
   <sourcePath />
+  <dependencies>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="false" scope="generate-into">fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)</dependency>
+  </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
@@ -96,12 +104,19 @@
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="52b771c2-b79f-4f44-98f2-d24fd25a210b(de.itemis.mps.baseLanguageExtensions)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
   <runtime>
     <dependency reexport="false">d91eaf6f-a378-467f-9524-0c201ee2e15f(de.itemis.mps.baseLanguageExtensions.runtime)</dependency>
   </runtime>
-  <extendedLanguages />
+  <extendedLanguages>
+    <extendedLanguage>f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</extendedLanguage>
+  </extendedLanguages>
 </language>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
@@ -2,16 +2,71 @@
 <model ref="r:e9626ecf-a0aa-465d-b5a3-3e84bb263ef5(de.itemis.mps.baseLanguageExtensions.generator.templates@generator)">
   <persistence version="9" />
   <languages>
+    <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="4" />
     <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
   </languages>
   <imports>
     <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" />
+    <import index="96gm" ref="r:2eaed950-3bc1-47cd-9b02-e917ff994d7c(de.itemis.mps.baseLanguageExtensions.runtime)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
   <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
     <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
-      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia" />
+      <concept id="1114706874351" name="jetbrains.mps.lang.generator.structure.CopySrcNodeMacro" flags="ln" index="29HgVG">
+        <child id="1168024447342" name="sourceNodeQuery" index="3NFExx" />
+      </concept>
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
+        <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
+      </concept>
+      <concept id="1177093525992" name="jetbrains.mps.lang.generator.structure.InlineTemplate_RuleConsequence" flags="lg" index="gft3U">
+        <child id="1177093586806" name="templateNode" index="gfFT$" />
+      </concept>
+      <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
+      <concept id="1167169308231" name="jetbrains.mps.lang.generator.structure.BaseMappingRule" flags="ng" index="30H$t8">
+        <reference id="1167169349424" name="applicableConcept" index="30HIoZ" />
+      </concept>
+      <concept id="1167327847730" name="jetbrains.mps.lang.generator.structure.Reduction_MappingRule" flags="lg" index="3aamgX">
+        <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
+      </concept>
+      <concept id="1168024337012" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodeQuery" flags="in" index="3NFfHV" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -19,6 +74,53 @@
   </registry>
   <node concept="bUwia" id="7EVAkaCx$5S">
     <property role="TrG5h" value="main" />
+    <node concept="3aamgX" id="2o8W23R_pD2" role="3acgRq">
+      <ref role="30HIoZ" to="pkab:w6MstC16Ds" resolve="ElvisOperation" />
+      <node concept="gft3U" id="2o8W23R_q1_" role="1lVwrX">
+        <node concept="2YIFZM" id="2o8W23R_q1T" role="gfFT$">
+          <ref role="37wK5l" to="96gm:w6MstBXHAP" resolve="apply" />
+          <ref role="1Pybhc" to="96gm:w6MstBXH_b" resolve="ElvisOperationUtil" />
+          <node concept="10Nm6u" id="2o8W23R_q23" role="37wK5m">
+            <node concept="29HgVG" id="2o8W23R_qdc" role="lGtFl">
+              <node concept="3NFfHV" id="2o8W23R_qeD" role="3NFExx">
+                <node concept="3clFbS" id="2o8W23R_qeE" role="2VODD2">
+                  <node concept="3clFbF" id="2o8W23R_qih" role="3cqZAp">
+                    <node concept="2OqwBi" id="2o8W23R_qxb" role="3clFbG">
+                      <node concept="30H73N" id="2o8W23R_qig" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="2o8W23R_r1N" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:fJuHU4s" resolve="leftExpression" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1bVj0M" id="2o8W23R_q2V" role="37wK5m">
+            <node concept="3clFbS" id="2o8W23R_q2X" role="1bW5cS">
+              <node concept="3clFbF" id="2o8W23R_q79" role="3cqZAp">
+                <node concept="10Nm6u" id="2o8W23R_q78" role="3clFbG">
+                  <node concept="29HgVG" id="2o8W23R_qaf" role="lGtFl">
+                    <node concept="3NFfHV" id="2o8W23R_r70" role="3NFExx">
+                      <node concept="3clFbS" id="2o8W23R_r71" role="2VODD2">
+                        <node concept="3clFbF" id="2o8W23R_raD" role="3cqZAp">
+                          <node concept="2OqwBi" id="2o8W23R_rcP" role="3clFbG">
+                            <node concept="30H73N" id="2o8W23R_raC" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="2o8W23R_rj0" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpee:fJuHU4r" resolve="rightExpression" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
@@ -4,7 +4,32 @@
   <languages>
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
+        <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="w6MstC16Ds">
+    <property role="EcuMT" value="578371460444482140" />
+    <property role="TrG5h" value="ElvisOperation" />
+    <property role="34LRSv" value="?:" />
+    <property role="R4oN_" value="elvis operation" />
+    <ref role="1TJDcQ" to="tpee:fJuHJVf" resolve="BinaryOperation" />
+  </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
@@ -5,7 +5,188 @@
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1766949807893567867" name="jetbrains.mps.lang.typesystem.structure.OverridesConceptFunction" flags="ig" index="bXqS6" />
+      <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
+        <child id="1185788644032" name="normalType" index="mwGJk" />
+      </concept>
+      <concept id="1185805035213" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteStatement" flags="nn" index="nvevp">
+        <child id="1185805047793" name="body" index="nvhr_" />
+        <child id="1185805056450" name="argument" index="nvjzm" />
+        <child id="1205761991995" name="argumentRepresentator" index="2X0Ygz" />
+      </concept>
+      <concept id="1220357310820" name="jetbrains.mps.lang.typesystem.structure.AddDependencyStatement" flags="nn" index="yXGxS">
+        <child id="1220357350423" name="dependency" index="yXQkb" />
+      </concept>
+      <concept id="1205762105978" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteVariableDeclaration" flags="ng" index="2X1qdy" />
+      <concept id="1205762656241" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteVariableReference" flags="nn" index="2X3wrD">
+        <reference id="1205762683928" name="whenConcreteVar" index="2X3Bk0" />
+      </concept>
+      <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
+        <child id="1195213635060" name="body" index="18ibNy" />
+      </concept>
+      <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
+        <reference id="1174642800329" name="concept" index="1YaFvo" />
+      </concept>
+      <concept id="1174643105530" name="jetbrains.mps.lang.typesystem.structure.InferenceRule" flags="ig" index="1YbPZF">
+        <child id="422148324487088858" name="overridesFun" index="ujSXK" />
+      </concept>
+      <concept id="1174648085619" name="jetbrains.mps.lang.typesystem.structure.AbstractRule" flags="ng" index="1YuPPy">
+        <child id="1174648101952" name="applicableNode" index="1YuTPh" />
+      </concept>
+      <concept id="1174650418652" name="jetbrains.mps.lang.typesystem.structure.ApplicableNodeReference" flags="nn" index="1YBJjd">
+        <reference id="1174650432090" name="applicableNode" index="1YBMHb" />
+      </concept>
+      <concept id="1174657487114" name="jetbrains.mps.lang.typesystem.structure.TypeOfExpression" flags="nn" index="1Z2H0r">
+        <child id="1174657509053" name="term" index="1Z2MuG" />
+      </concept>
+      <concept id="1174660718586" name="jetbrains.mps.lang.typesystem.structure.AbstractEquationStatement" flags="nn" index="1Zf1VF">
+        <child id="1174660783413" name="leftExpression" index="1ZfhK$" />
+        <child id="1174660783414" name="rightExpression" index="1ZfhKB" />
+      </concept>
+      <concept id="1174663239020" name="jetbrains.mps.lang.typesystem.structure.CreateGreaterThanInequationStatement" flags="nn" index="1ZoDhX" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1YbPZF" id="w6MstC1zne">
+    <property role="TrG5h" value="typeof_ElvisOperation" />
+    <node concept="3clFbS" id="w6MstC1znf" role="18ibNy">
+      <node concept="yXGxS" id="w6MstC1JR3" role="3cqZAp">
+        <node concept="2OqwBi" id="w6MstC1K1M" role="yXQkb">
+          <node concept="1YBJjd" id="w6MstC1JRd" role="2Oq$k0">
+            <ref role="1YBMHb" node="w6MstC1znh" resolve="elvisOperation" />
+          </node>
+          <node concept="3TrEf2" id="w6MstC1KEC" role="2OqNvi">
+            <ref role="3Tt5mk" to="tpee:fJuHU4s" resolve="leftExpression" />
+          </node>
+        </node>
+      </node>
+      <node concept="yXGxS" id="w6MstC1KGi" role="3cqZAp">
+        <node concept="2OqwBi" id="w6MstC1KGj" role="yXQkb">
+          <node concept="1YBJjd" id="w6MstC1KGk" role="2Oq$k0">
+            <ref role="1YBMHb" node="w6MstC1znh" resolve="elvisOperation" />
+          </node>
+          <node concept="3TrEf2" id="w6MstC1KGl" role="2OqNvi">
+            <ref role="3Tt5mk" to="tpee:fJuHU4r" resolve="rightExpression" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="w6MstC1JQY" role="3cqZAp" />
+      <node concept="nvevp" id="w6MstC1znq" role="3cqZAp">
+        <node concept="3clFbS" id="w6MstC1znr" role="nvhr_">
+          <node concept="nvevp" id="2o8W23RtBpD" role="3cqZAp">
+            <node concept="3clFbS" id="2o8W23RtBpF" role="nvhr_">
+              <node concept="1ZoDhX" id="2o8W23RtCmv" role="3cqZAp">
+                <node concept="mw_s8" id="2o8W23RtCmw" role="1ZfhK$">
+                  <node concept="1Z2H0r" id="2o8W23RtCmx" role="mwGJk">
+                    <node concept="1YBJjd" id="2o8W23RtCmy" role="1Z2MuG">
+                      <ref role="1YBMHb" node="w6MstC1znh" resolve="elvisOperation" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="mw_s8" id="2o8W23RtCmz" role="1ZfhKB">
+                  <node concept="2X3wrD" id="2o8W23RtCm$" role="mwGJk">
+                    <ref role="2X3Bk0" node="2o8W23RtBpJ" resolve="rhsType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1ZoDhX" id="w6MstC1_2G" role="3cqZAp">
+                <node concept="mw_s8" id="w6MstC1_2I" role="1ZfhK$">
+                  <node concept="1Z2H0r" id="w6MstC1_2J" role="mwGJk">
+                    <node concept="1YBJjd" id="w6MstC1_2K" role="1Z2MuG">
+                      <ref role="1YBMHb" node="w6MstC1znh" resolve="elvisOperation" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="mw_s8" id="w6MstC1_6p" role="1ZfhKB">
+                  <node concept="2X3wrD" id="w6MstC1_6n" role="mwGJk">
+                    <ref role="2X3Bk0" node="w6MstC1znt" resolve="lhsType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Z2H0r" id="2o8W23RtBpT" role="nvjzm">
+              <node concept="2OqwBi" id="2o8W23RtB_u" role="1Z2MuG">
+                <node concept="1YBJjd" id="2o8W23RtBqj" role="2Oq$k0">
+                  <ref role="1YBMHb" node="w6MstC1znh" resolve="elvisOperation" />
+                </node>
+                <node concept="3TrEf2" id="2o8W23RtCk2" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tpee:fJuHU4r" resolve="rightExpression" />
+                </node>
+              </node>
+            </node>
+            <node concept="2X1qdy" id="2o8W23RtBpJ" role="2X0Ygz">
+              <property role="TrG5h" value="rhsType" />
+              <node concept="2jxLKc" id="2o8W23RtBpK" role="1tU5fm" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Z2H0r" id="w6MstC1znA" role="nvjzm">
+          <node concept="2OqwBi" id="w6MstC1zyR" role="1Z2MuG">
+            <node concept="1YBJjd" id="w6MstC1zo0" role="2Oq$k0">
+              <ref role="1YBMHb" node="w6MstC1znh" resolve="elvisOperation" />
+            </node>
+            <node concept="3TrEf2" id="w6MstC1$9m" role="2OqNvi">
+              <ref role="3Tt5mk" to="tpee:fJuHU4s" resolve="leftExpression" />
+            </node>
+          </node>
+        </node>
+        <node concept="2X1qdy" id="w6MstC1znt" role="2X0Ygz">
+          <property role="TrG5h" value="lhsType" />
+          <node concept="2jxLKc" id="w6MstC1znu" role="1tU5fm" />
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="w6MstC1znh" role="1YuTPh">
+      <property role="TrG5h" value="elvisOperation" />
+      <ref role="1YaFvo" to="pkab:w6MstC16Ds" resolve="ElvisOperation" />
+    </node>
+    <node concept="bXqS6" id="2o8W23REgK7" role="ujSXK">
+      <node concept="3clFbS" id="2o8W23REgK8" role="2VODD2">
+        <node concept="3clFbF" id="2o8W23REhiH" role="3cqZAp">
+          <node concept="3clFbT" id="2o8W23REhiG" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/solutions/de.itemis.mps.baseLanguageExtensions.test/de.itemis.mps.baseLanguageExtensions.test.msd
+++ b/code/solutions/de.itemis.mps.baseLanguageExtensions.test/de.itemis.mps.baseLanguageExtensions.test.msd
@@ -11,8 +11,22 @@
     </facet>
   </facets>
   <sourcePath />
-  <languageVersions />
+  <dependencies>
+    <dependency reexport="false">d91eaf6f-a378-467f-9524-0c201ee2e15f(de.itemis.mps.baseLanguageExtensions.runtime)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
   <dependencyVersions>
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="d91eaf6f-a378-467f-9524-0c201ee2e15f(de.itemis.mps.baseLanguageExtensions.runtime)" version="0" />
     <module reference="6f208df3-71dd-4d85-97d4-cc55c1d5b8e4(de.itemis.mps.baseLanguageExtensions.test)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.elvisOperator@tests.mps
+++ b/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.elvisOperator@tests.mps
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:e155915b-469c-4f65-8ff6-a3dceadbfe03(de.itemis.mps.baseLanguageExtensions.test.elvisOperator@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+  </languages>
+  <imports>
+    <import index="96gm" ref="r:2eaed950-3bc1-47cd-9b02-e917ff994d7c(de.itemis.mps.baseLanguageExtensions.runtime)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+      </concept>
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171931690126" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethod" flags="ig" index="3s$Bmu">
+        <property id="1171931690128" name="methodName" index="3s$Bm0" />
+      </concept>
+      <concept id="1171931851043" name="jetbrains.mps.baseLanguage.unitTest.structure.BTestCase" flags="ig" index="3s_ewN">
+        <property id="1171931851045" name="testCaseName" index="3s_ewP" />
+        <child id="1171931851044" name="testMethodList" index="3s_ewO" />
+      </concept>
+      <concept id="1171931858461" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethodList" flags="ng" index="3s_gsd">
+        <child id="1171931858462" name="testMethod" index="3s_gse" />
+      </concept>
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1172017222794" name="jetbrains.mps.baseLanguage.unitTest.structure.Fail" flags="nn" index="3xETmq" />
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ng" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="3s_ewN" id="w6MstBY8cQ">
+    <property role="3s_ewP" value="ElvisOperation" />
+    <node concept="3Tm1VV" id="w6MstBY8cR" role="1B3o_S" />
+    <node concept="3s_gsd" id="w6MstBY8cS" role="3s_ewO">
+      <node concept="3s$Bmu" id="w6MstBY8dD" role="3s_gse">
+        <property role="3s$Bm0" value="rightHandSideIsEvaluatedOnce" />
+        <node concept="3cqZAl" id="w6MstBY8dE" role="3clF45" />
+        <node concept="3Tm1VV" id="w6MstBY8dF" role="1B3o_S" />
+        <node concept="3clFbS" id="w6MstBY8dG" role="3clF47">
+          <node concept="3cpWs8" id="w6MstBY8gc" role="3cqZAp">
+            <node concept="3cpWsn" id="w6MstBY8gf" role="3cpWs9">
+              <property role="TrG5h" value="lhs" />
+              <node concept="17QB3L" id="w6MstBY8ga" role="1tU5fm" />
+              <node concept="10Nm6u" id="w6MstBY8h3" role="33vP2m" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="w6MstBY8eg" role="3cqZAp">
+            <node concept="3cpWsn" id="w6MstBY8ej" role="3cpWs9">
+              <property role="TrG5h" value="counter" />
+              <node concept="10Oyi0" id="w6MstBY8ef" role="1tU5fm" />
+              <node concept="3cmrfG" id="w6MstBY8eV" role="33vP2m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="w6MstBY9rF" role="3cqZAp">
+            <node concept="3cpWsn" id="w6MstBY9rG" role="3cpWs9">
+              <property role="TrG5h" value="rhs" />
+              <node concept="1ajhzC" id="w6MstBY9rD" role="1tU5fm">
+                <node concept="10Oyi0" id="w6MstBY9rE" role="1ajl9A" />
+              </node>
+              <node concept="1bVj0M" id="w6MstBY9rH" role="33vP2m">
+                <node concept="3clFbS" id="w6MstBY9rI" role="1bW5cS">
+                  <node concept="3clFbF" id="w6MstBY9rJ" role="3cqZAp">
+                    <node concept="3uNrnE" id="w6MstBY9rK" role="3clFbG">
+                      <node concept="37vLTw" id="w6MstBY9rL" role="2$L3a6">
+                        <ref role="3cqZAo" node="w6MstBY8ej" resolve="counter" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="w6MstBY9t3" role="3cqZAp" />
+          <node concept="3clFbF" id="w6MstBY9tN" role="3cqZAp">
+            <node concept="2YIFZM" id="w6MstBY9BY" role="3clFbG">
+              <ref role="37wK5l" to="96gm:w6MstBXHAP" resolve="apply" />
+              <ref role="1Pybhc" to="96gm:w6MstBXH_b" resolve="ElvisOperationUtil" />
+              <node concept="37vLTw" id="w6MstBY9Cm" role="37wK5m">
+                <ref role="3cqZAo" node="w6MstBY8gf" resolve="lhs" />
+              </node>
+              <node concept="37vLTw" id="w6MstBY9Mo" role="37wK5m">
+                <ref role="3cqZAo" node="w6MstBY9rG" resolve="rhs" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="w6MstBYdu3" role="3cqZAp" />
+          <node concept="3vlDli" id="w6MstBYdQK" role="3cqZAp">
+            <node concept="3cmrfG" id="w6MstBYefu" role="3tpDZB">
+              <property role="3cmrfH" value="1" />
+            </node>
+            <node concept="37vLTw" id="w6MstBYexV" role="3tpDZA">
+              <ref role="3cqZAo" node="w6MstBY8ej" resolve="counter" />
+            </node>
+            <node concept="3_1$Yv" id="w6MstBYvYA" role="3_9lra">
+              <node concept="Xl_RD" id="w6MstBYwoB" role="3_1BAH">
+                <property role="Xl_RC" value="right hand side was not evaluated or more than once" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="w6MstBYeUt" role="3s_gse">
+        <property role="3s$Bm0" value="rightHandSideIsNotEvaluated" />
+        <node concept="3cqZAl" id="w6MstBYeUu" role="3clF45" />
+        <node concept="3Tm1VV" id="w6MstBYeUv" role="1B3o_S" />
+        <node concept="3clFbS" id="w6MstBYeUw" role="3clF47">
+          <node concept="3cpWs8" id="w6MstBYfis" role="3cqZAp">
+            <node concept="3cpWsn" id="w6MstBYfiv" role="3cpWs9">
+              <property role="TrG5h" value="lhs" />
+              <node concept="17QB3L" id="w6MstBYfir" role="1tU5fm" />
+              <node concept="Xl_RD" id="w6MstBYrDO" role="33vP2m">
+                <property role="Xl_RC" value="" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="w6MstBYfka" role="3cqZAp">
+            <node concept="3cpWsn" id="w6MstBYfkd" role="3cpWs9">
+              <property role="TrG5h" value="rhs" />
+              <node concept="1ajhzC" id="w6MstBYfk6" role="1tU5fm">
+                <node concept="10Oyi0" id="w6MstBYfko" role="1ajl9A" />
+              </node>
+              <node concept="1bVj0M" id="w6MstBYfld" role="33vP2m">
+                <node concept="3clFbS" id="w6MstBYflf" role="1bW5cS">
+                  <node concept="3xETmq" id="w6MstBYfnP" role="3cqZAp">
+                    <node concept="3_1$Yv" id="w6MstBYfoz" role="3_9lra">
+                      <node concept="Xl_RD" id="w6MstBYfr2" role="3_1BAH">
+                        <property role="Xl_RC" value="right hand side was evaluated where it shouldn't have been" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs6" id="w6MstBYf_2" role="3cqZAp">
+                    <node concept="3cmrfG" id="w6MstBYfB2" role="3cqZAk">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="w6MstBYfBT" role="3cqZAp" />
+          <node concept="3clFbF" id="w6MstBYfCs" role="3cqZAp">
+            <node concept="2YIFZM" id="w6MstBYfCR" role="3clFbG">
+              <ref role="37wK5l" to="96gm:w6MstBXHAP" resolve="apply" />
+              <ref role="1Pybhc" to="96gm:w6MstBXH_b" resolve="ElvisOperationUtil" />
+              <node concept="37vLTw" id="w6MstBYfTz" role="37wK5m">
+                <ref role="3cqZAo" node="w6MstBYfiv" resolve="lhs" />
+              </node>
+              <node concept="37vLTw" id="w6MstBYg0t" role="37wK5m">
+                <ref role="3cqZAo" node="w6MstBYfkd" resolve="rhs" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="w6MstBYF12" role="3s_gse">
+        <property role="3s$Bm0" value="rightHandSideIsReturned" />
+        <node concept="3cqZAl" id="w6MstBYF13" role="3clF45" />
+        <node concept="3Tm1VV" id="w6MstBYF14" role="1B3o_S" />
+        <node concept="3clFbS" id="w6MstBYF15" role="3clF47">
+          <node concept="3cpWs8" id="w6MstBYIJE" role="3cqZAp">
+            <node concept="3cpWsn" id="w6MstBYIJH" role="3cpWs9">
+              <property role="TrG5h" value="lhs" />
+              <node concept="17QB3L" id="w6MstBYIJD" role="1tU5fm" />
+              <node concept="10Nm6u" id="w6MstBYIKB" role="33vP2m" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="w6MstBYILD" role="3cqZAp">
+            <node concept="3cpWsn" id="w6MstBYILG" role="3cpWs9">
+              <property role="TrG5h" value="rhs" />
+              <node concept="10Oyi0" id="w6MstBYILB" role="1tU5fm" />
+              <node concept="3cmrfG" id="w6MstBYIMd" role="33vP2m">
+                <property role="3cmrfH" value="42" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="w6MstBYIMH" role="3cqZAp" />
+          <node concept="3cpWs8" id="w6MstBYIUL" role="3cqZAp">
+            <node concept="3cpWsn" id="w6MstBYIUM" role="3cpWs9">
+              <property role="TrG5h" value="actual" />
+              <node concept="3uibUv" id="w6MstBYIUN" role="1tU5fm">
+                <ref role="3uigEE" to="guwi:~Serializable" resolve="Serializable" />
+              </node>
+              <node concept="2YIFZM" id="w6MstBYMFS" role="33vP2m">
+                <ref role="37wK5l" to="96gm:w6MstBXHAP" resolve="apply" />
+                <ref role="1Pybhc" to="96gm:w6MstBXH_b" resolve="ElvisOperationUtil" />
+                <node concept="37vLTw" id="w6MstBYMGC" role="37wK5m">
+                  <ref role="3cqZAo" node="w6MstBYIJH" resolve="lhs" />
+                </node>
+                <node concept="1bVj0M" id="w6MstBYMJC" role="37wK5m">
+                  <node concept="3clFbS" id="w6MstBYMJE" role="1bW5cS">
+                    <node concept="3clFbF" id="w6MstBYNmB" role="3cqZAp">
+                      <node concept="37vLTw" id="w6MstBYNmA" role="3clFbG">
+                        <ref role="3cqZAo" node="w6MstBYILG" resolve="rhs" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="w6MstBYQhF" role="3cqZAp" />
+          <node concept="3vlDli" id="w6MstBYR61" role="3cqZAp">
+            <node concept="3cmrfG" id="w6MstBYRvX" role="3tpDZB">
+              <property role="3cmrfH" value="42" />
+            </node>
+            <node concept="37vLTw" id="w6MstBYRU4" role="3tpDZA">
+              <ref role="3cqZAo" node="w6MstBYIUM" resolve="actual" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="w6MstBYSj9" role="3s_gse">
+        <property role="3s$Bm0" value="leftHandSideIsReturned" />
+        <node concept="3cqZAl" id="w6MstBYSja" role="3clF45" />
+        <node concept="3Tm1VV" id="w6MstBYSjb" role="1B3o_S" />
+        <node concept="3clFbS" id="w6MstBYSjc" role="3clF47">
+          <node concept="3cpWs8" id="w6MstBYTrV" role="3cqZAp">
+            <node concept="3cpWsn" id="w6MstBYTrY" role="3cpWs9">
+              <property role="TrG5h" value="lhs" />
+              <node concept="17QB3L" id="w6MstBYTrU" role="1tU5fm" />
+              <node concept="Xl_RD" id="w6MstBYTsp" role="33vP2m">
+                <property role="Xl_RC" value="42" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="w6MstBYTsK" role="3cqZAp" />
+          <node concept="3cpWs8" id="w6MstBYUym" role="3cqZAp">
+            <node concept="3cpWsn" id="w6MstBYUyp" role="3cpWs9">
+              <property role="TrG5h" value="actual" />
+              <node concept="17QB3L" id="w6MstBYUyk" role="1tU5fm" />
+              <node concept="2YIFZM" id="w6MstBYUzH" role="33vP2m">
+                <ref role="37wK5l" to="96gm:w6MstBXHAP" resolve="apply" />
+                <ref role="1Pybhc" to="96gm:w6MstBXH_b" resolve="ElvisOperationUtil" />
+                <node concept="37vLTw" id="w6MstBYUON" role="37wK5m">
+                  <ref role="3cqZAo" node="w6MstBYTrY" resolve="lhs" />
+                </node>
+                <node concept="1bVj0M" id="w6MstBYUPK" role="37wK5m">
+                  <node concept="3clFbS" id="w6MstBYUPM" role="1bW5cS">
+                    <node concept="3clFbF" id="w6MstBYVtw" role="3cqZAp">
+                      <node concept="10Nm6u" id="w6MstBYVtv" role="3clFbG" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="w6MstBYV$L" role="3cqZAp" />
+          <node concept="3vlDli" id="w6MstBYVCr" role="3cqZAp">
+            <node concept="Xl_RD" id="w6MstBYVE1" role="3tpDZB">
+              <property role="Xl_RC" value="42" />
+            </node>
+            <node concept="37vLTw" id="w6MstBYVHi" role="3tpDZA">
+              <ref role="3cqZAo" node="w6MstBYUyp" resolve="actual" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+


### PR DESCRIPTION
## Name
Elvis Operation (?:)

## Operation Type
Binary Operation

## Use Case
When handling nullable values and you want to prevent NullPointerExceptions and have a "safe fallback value" of sorts, you can use the Elvis Operation to achieve a semantic similar to the ternary operation expression that will select and return your fallback, should the nullable value actually be null.

```
null ?: "fallback" -> result: "fallback"
"valid" ?: "fallback" -> "valid"
"valid" ?: null -> "valid"
null ?: null -> null
```

The operation will also be able to widen the typing to a common supertype, in case the fallback isn't immediately a subtype of the left hand side.

## Comments
Technically, the correct (or more correct) operation to react on null and replace this by some other fallback value would be the null-coalescing operator (??) like it is defined in C#, but as Kotlin has decided to use the Elvis operation - which technically falls back to the right hand side for anything that looks vaguely false-y and not just for null/undefined - we adopted this operation for MPS as well.