### PR TITLE
Add the GroupByOperation to the new base language extensions

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -9890,6 +9890,16 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="54jQkZ8WKrY" role="3bR37C">
+          <node concept="3bR9La" id="54jQkZ8WKrZ" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="54jQkZ8WKs0" role="3bR37C">
+          <node concept="3bR9La" id="54jQkZ8WKs1" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L0C" resolve="collections.runtime" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="m$_wf" id="5Jv8_iJNYP8" role="3989C9">
@@ -19782,6 +19792,11 @@
         <node concept="1SiIV0" id="vJfcQmgs$I" role="3bR37C">
           <node concept="3bR9La" id="vJfcQmgs$J" role="1SiIV1">
             <ref role="3bR37D" node="vJfcQmbzfZ" resolve="de.itemis.mps.baseLanguageExtensions.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="54jQkZ8WJHM" role="3bR37C">
+          <node concept="3bR9La" id="54jQkZ8WJHN" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L0C" resolve="collections.runtime" />
           </node>
         </node>
       </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/de.itemis.mps.baseLanguageExtensions.runtime.msd
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/de.itemis.mps.baseLanguageExtensions.runtime.msd
@@ -11,6 +11,10 @@
     </facet>
   </facets>
   <sourcePath />
+  <dependencies>
+    <dependency reexport="false">9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
@@ -21,6 +25,8 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
     <module reference="d91eaf6f-a378-467f-9524-0c201ee2e15f(de.itemis.mps.baseLanguageExtensions.runtime)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/models/de.itemis.mps.baseLanguageExtensions.runtime.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/models/de.itemis.mps.baseLanguageExtensions.runtime.mps
@@ -9,7 +9,10 @@
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />
   </languages>
-  <imports />
+  <imports>
+    <import index="urs3" ref="r:fc76aa36-3cff-41c7-b94b-eee0e8341932(jetbrains.mps.internal.collections.runtime)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+  </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
       <concept id="1238852151516" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleType" flags="in" index="1LlUBW">
@@ -26,6 +29,7 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1153422305557" name="jetbrains.mps.baseLanguage.structure.LessThanOrEqualsExpression" flags="nn" index="2dkUwp" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
         <child id="1076505808688" name="condition" index="2$JKZa" />
@@ -44,11 +48,21 @@
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ" />
       <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
@@ -95,9 +109,25 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+        <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -123,11 +153,15 @@
       </concept>
       <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
         <child id="1199542457201" name="resultType" index="1ajl9A" />
+        <child id="1199542501692" name="parameterType" index="1ajw0F" />
       </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
-      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e" />
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e">
+        <child id="1225797361612" name="parameter" index="1BdPVh" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -489,6 +523,198 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="6vHuLLnJvpd" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="54jQkZ8QoGe">
+    <property role="TrG5h" value="GroupByOperationUtil" />
+    <node concept="2YIFZL" id="54jQkZ8QoHD" role="jymVt">
+      <property role="TrG5h" value="apply" />
+      <node concept="3clFbS" id="54jQkZ8QoHG" role="3clF47">
+        <node concept="3cpWs8" id="54jQkZ8R36P" role="3cqZAp">
+          <node concept="3cpWsn" id="54jQkZ8R36Q" role="3cpWs9">
+            <property role="TrG5h" value="cache" />
+            <node concept="3uibUv" id="54jQkZ8R36N" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
+              <node concept="16syzq" id="54jQkZ8R3wI" role="11_B2D">
+                <ref role="16sUi3" node="54jQkZ8QpwM" resolve="K" />
+              </node>
+              <node concept="3uibUv" id="54jQkZ8R3Xb" role="11_B2D">
+                <ref role="3uigEE" to="urs3:5Ffu4tBUx5R" resolve="ISequence" />
+                <node concept="16syzq" id="54jQkZ8R4qE" role="11_B2D">
+                  <ref role="16sUi3" node="54jQkZ8QoI8" resolve="T" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="54jQkZ8R56d" role="33vP2m">
+              <node concept="1pGfFk" id="54jQkZ8R6Ug" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="33ny:~HashMap.&lt;init&gt;()" resolve="HashMap" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="54jQkZ8RztP" role="3cqZAp">
+          <node concept="2OqwBi" id="54jQkZ8R$PK" role="3clFbG">
+            <node concept="37vLTw" id="54jQkZ8RztN" role="2Oq$k0">
+              <ref role="3cqZAo" node="54jQkZ8QoIN" resolve="seq" />
+            </node>
+            <node concept="liA8E" id="54jQkZ8RCeI" role="2OqNvi">
+              <ref role="37wK5l" to="urs3:5Ffu4tBUx7B" resolve="visitAll" />
+              <node concept="1bVj0M" id="54jQkZ8S7B8" role="37wK5m">
+                <node concept="3clFbS" id="54jQkZ8S7B9" role="1bW5cS">
+                  <node concept="3cpWs8" id="54jQkZ8S7Ba" role="3cqZAp">
+                    <node concept="3cpWsn" id="54jQkZ8S7Bb" role="3cpWs9">
+                      <property role="TrG5h" value="key" />
+                      <node concept="16syzq" id="54jQkZ8S7Bc" role="1tU5fm">
+                        <ref role="16sUi3" node="54jQkZ8QpwM" resolve="K" />
+                      </node>
+                      <node concept="2OqwBi" id="54jQkZ8S7Bd" role="33vP2m">
+                        <node concept="37vLTw" id="54jQkZ8S7Be" role="2Oq$k0">
+                          <ref role="3cqZAo" node="54jQkZ8Qpvu" resolve="keyExtract" />
+                        </node>
+                        <node concept="1Bd96e" id="54jQkZ8S7Bf" role="2OqNvi">
+                          <node concept="37vLTw" id="54jQkZ8S7Bg" role="1BdPVh">
+                            <ref role="3cqZAo" node="54jQkZ8S7BC" resolve="elem" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="54jQkZ8S7Bh" role="3cqZAp">
+                    <node concept="3fqX7Q" id="54jQkZ8S7Bi" role="3clFbw">
+                      <node concept="2OqwBi" id="54jQkZ8S7Bj" role="3fr31v">
+                        <node concept="37vLTw" id="54jQkZ8S7Bk" role="2Oq$k0">
+                          <ref role="3cqZAo" node="54jQkZ8R36Q" resolve="cache" />
+                        </node>
+                        <node concept="liA8E" id="54jQkZ8S7Bl" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~Map.containsKey(java.lang.Object)" resolve="containsKey" />
+                          <node concept="37vLTw" id="54jQkZ8S7Bm" role="37wK5m">
+                            <ref role="3cqZAo" node="54jQkZ8S7Bb" resolve="key" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="54jQkZ8S7Bn" role="3clFbx">
+                      <node concept="3clFbF" id="54jQkZ8S7Bo" role="3cqZAp">
+                        <node concept="2OqwBi" id="54jQkZ8S7Bp" role="3clFbG">
+                          <node concept="37vLTw" id="54jQkZ8S7Bq" role="2Oq$k0">
+                            <ref role="3cqZAo" node="54jQkZ8R36Q" resolve="cache" />
+                          </node>
+                          <node concept="liA8E" id="54jQkZ8S7Br" role="2OqNvi">
+                            <ref role="37wK5l" to="33ny:~Map.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                            <node concept="37vLTw" id="54jQkZ8S7Bs" role="37wK5m">
+                              <ref role="3cqZAo" node="54jQkZ8S7Bb" resolve="key" />
+                            </node>
+                            <node concept="2YIFZM" id="54jQkZ8ST1S" role="37wK5m">
+                              <ref role="37wK5l" to="urs3:5Ffu4tBUyJX" resolve="fromArray" />
+                              <ref role="1Pybhc" to="urs3:5Ffu4tBUyJF" resolve="ListSequence" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="54jQkZ8S7Bw" role="3cqZAp">
+                    <node concept="2OqwBi" id="54jQkZ8S7Bx" role="3clFbG">
+                      <node concept="liA8E" id="54jQkZ8S7BA" role="2OqNvi">
+                        <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                        <node concept="37vLTw" id="54jQkZ8S7BB" role="37wK5m">
+                          <ref role="3cqZAo" node="54jQkZ8S7BC" resolve="elem" />
+                        </node>
+                      </node>
+                      <node concept="1eOMI4" id="54jQkZ8Tedk" role="2Oq$k0">
+                        <node concept="10QFUN" id="54jQkZ8Tedh" role="1eOMHV">
+                          <node concept="3uibUv" id="54jQkZ8Tg2M" role="10QFUM">
+                            <ref role="3uigEE" to="urs3:5Ffu4tBUyv1" resolve="IListSequence" />
+                            <node concept="16syzq" id="54jQkZ8TiOt" role="11_B2D">
+                              <ref role="16sUi3" node="54jQkZ8QoI8" resolve="T" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="54jQkZ8S7By" role="10QFUP">
+                            <node concept="37vLTw" id="54jQkZ8S7Bz" role="2Oq$k0">
+                              <ref role="3cqZAo" node="54jQkZ8R36Q" resolve="cache" />
+                            </node>
+                            <node concept="liA8E" id="54jQkZ8S7B$" role="2OqNvi">
+                              <ref role="37wK5l" to="33ny:~Map.get(java.lang.Object)" resolve="get" />
+                              <node concept="37vLTw" id="54jQkZ8S7B_" role="37wK5m">
+                                <ref role="3cqZAo" node="54jQkZ8S7Bb" resolve="key" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTG" id="54jQkZ8S7BC" role="1bW2Oz">
+                  <property role="TrG5h" value="elem" />
+                  <node concept="16syzq" id="54jQkZ8S7BD" role="1tU5fm">
+                    <ref role="16sUi3" node="54jQkZ8QoI8" resolve="T" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="54jQkZ8QS3r" role="3cqZAp">
+          <node concept="2YIFZM" id="54jQkZ8SdyN" role="3clFbG">
+            <ref role="37wK5l" to="urs3:5Ffu4tBUzHn" resolve="fromMap" />
+            <ref role="1Pybhc" to="urs3:5Ffu4tBUzBg" resolve="MapSequence" />
+            <node concept="16syzq" id="54jQkZ8SdyO" role="3PaCim">
+              <ref role="16sUi3" node="54jQkZ8QpwM" resolve="K" />
+            </node>
+            <node concept="3uibUv" id="54jQkZ8Swgo" role="3PaCim">
+              <ref role="3uigEE" to="urs3:5Ffu4tBUx5R" resolve="ISequence" />
+              <node concept="16syzq" id="54jQkZ8SxY3" role="11_B2D">
+                <ref role="16sUi3" node="54jQkZ8QoI8" resolve="T" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="54jQkZ8Sez5" role="37wK5m">
+              <ref role="3cqZAo" node="54jQkZ8R36Q" resolve="cache" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="54jQkZ8QoH9" role="1B3o_S" />
+      <node concept="3uibUv" id="54jQkZ8QQ0a" role="3clF45">
+        <ref role="3uigEE" to="urs3:5Ffu4tBU$6H" resolve="IMapSequence" />
+        <node concept="16syzq" id="54jQkZ8QQ11" role="11_B2D">
+          <ref role="16sUi3" node="54jQkZ8QpwM" resolve="K" />
+        </node>
+        <node concept="3uibUv" id="54jQkZ8QQ1W" role="11_B2D">
+          <ref role="3uigEE" to="urs3:5Ffu4tBUx5R" resolve="ISequence" />
+          <node concept="16syzq" id="54jQkZ8QQ3y" role="11_B2D">
+            <ref role="16sUi3" node="54jQkZ8QoI8" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="16euLQ" id="54jQkZ8QoI8" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+      <node concept="16euLQ" id="54jQkZ8QpwM" role="16eVyc">
+        <property role="TrG5h" value="K" />
+      </node>
+      <node concept="37vLTG" id="54jQkZ8QoIN" role="3clF46">
+        <property role="TrG5h" value="seq" />
+        <node concept="3uibUv" id="54jQkZ8QoIM" role="1tU5fm">
+          <ref role="3uigEE" to="urs3:5Ffu4tBUx5R" resolve="ISequence" />
+          <node concept="16syzq" id="54jQkZ8QpuE" role="11_B2D">
+            <ref role="16sUi3" node="54jQkZ8QoI8" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="54jQkZ8Qpvu" role="3clF46">
+        <property role="TrG5h" value="keyExtract" />
+        <node concept="1ajhzC" id="54jQkZ8QpvV" role="1tU5fm">
+          <node concept="16syzq" id="54jQkZ8Qpxs" role="1ajl9A">
+            <ref role="16sUi3" node="54jQkZ8QpwM" resolve="K" />
+          </node>
+          <node concept="16syzq" id="54jQkZ8Qpwm" role="1ajw0F">
+            <ref role="16sUi3" node="54jQkZ8QoI8" resolve="T" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="54jQkZ8QoGf" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
@@ -42,6 +42,7 @@
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -54,7 +55,12 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271484915" name="jetbrains.mps.baseLanguage.structure.SubstringExpression" flags="nn" index="17RM3I">
+        <child id="1225271484916" name="operand" index="17RM3D" />
+        <child id="1225271484918" name="endIndex" index="17RM3F" />
+      </concept>
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -69,6 +75,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -81,6 +90,7 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -120,6 +130,7 @@
       <concept id="571742531387697460" name="de.itemis.mps.baseLanguageExtensions.structure.IntegerRangeConstantBound" flags="ng" index="2hHTnT">
         <property id="7488777117046563852" name="value" index="KjLWg" />
       </concept>
+      <concept id="5842252078326680676" name="de.itemis.mps.baseLanguageExtensions.structure.GroupByOperation" flags="ng" index="2pSdkF" />
       <concept id="7488777117048605758" name="de.itemis.mps.baseLanguageExtensions.structure.ZipOperation" flags="ng" index="Kbfsy" />
       <concept id="578371460444482140" name="de.itemis.mps.baseLanguageExtensions.structure.ElvisOperation" flags="ng" index="1w0Eer" />
     </language>
@@ -155,11 +166,21 @@
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
+        <child id="1197683466920" name="keyType" index="3rvQeY" />
+        <child id="1197683475734" name="valueType" index="3rvSg0" />
+      </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
         <child id="1240687658305" name="delimiter" index="3uJOhx" />
       </concept>
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
+        <child id="1197932505799" name="map" index="3ElQJh" />
+        <child id="1197932525128" name="key" index="3ElVtu" />
+      </concept>
     </language>
   </registry>
   <node concept="312cEu" id="w6MstC1zab">
@@ -944,6 +965,205 @@
       <node concept="3cqZAl" id="6vHuLLnKQXJ" role="3clF45" />
     </node>
     <node concept="3Tm1VV" id="6vHuLLnKQWd" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="54jQkZ8XvIU">
+    <property role="TrG5h" value="GroupByOperationSandbox" />
+    <node concept="2YIFZL" id="54jQkZ8Xzz5" role="jymVt">
+      <property role="TrG5h" value="usage" />
+      <node concept="3clFbS" id="54jQkZ8Xzz8" role="3clF47">
+        <node concept="3cpWs8" id="54jQkZ8Xz$_" role="3cqZAp">
+          <node concept="3cpWsn" id="54jQkZ8Xz$C" role="3cpWs9">
+            <property role="TrG5h" value="numbers" />
+            <node concept="A3Dl8" id="54jQkZ8Xz$z" role="1tU5fm">
+              <node concept="17QB3L" id="54jQkZ8Xz_a" role="A3Ik2" />
+            </node>
+            <node concept="2ShNRf" id="54jQkZ8XzBC" role="33vP2m">
+              <node concept="Tc6Ow" id="54jQkZ8X$7c" role="2ShVmc">
+                <node concept="17QB3L" id="54jQkZ8X$QM" role="HW$YZ" />
+                <node concept="Xl_RD" id="54jQkZ8X_n3" role="HW$Y0">
+                  <property role="Xl_RC" value="One" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8X_rj" role="HW$Y0">
+                  <property role="Xl_RC" value="Two" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8X_uJ" role="HW$Y0">
+                  <property role="Xl_RC" value="Three" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8X_xf" role="HW$Y0">
+                  <property role="Xl_RC" value="Four" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8X__9" role="HW$Y0">
+                  <property role="Xl_RC" value="Five" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8X_AC" role="HW$Y0">
+                  <property role="Xl_RC" value="Six" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8X_DA" role="HW$Y0">
+                  <property role="Xl_RC" value="Seven" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8X_GI" role="HW$Y0">
+                  <property role="Xl_RC" value="Eight" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8X_Na" role="HW$Y0">
+                  <property role="Xl_RC" value="Nine" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="54jQkZ973p6" role="3cqZAp">
+          <node concept="3cpWsn" id="54jQkZ973p7" role="3cpWs9">
+            <property role="TrG5h" value="byLength" />
+            <node concept="3rvAFt" id="54jQkZ973od" role="1tU5fm">
+              <node concept="10Oyi0" id="54jQkZ973om" role="3rvQeY" />
+              <node concept="A3Dl8" id="54jQkZ973on" role="3rvSg0">
+                <node concept="17QB3L" id="54jQkZ973oo" role="A3Ik2" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="54jQkZ973p8" role="33vP2m">
+              <node concept="37vLTw" id="54jQkZ973p9" role="2Oq$k0">
+                <ref role="3cqZAo" node="54jQkZ8Xz$C" resolve="numbers" />
+              </node>
+              <node concept="2pSdkF" id="54jQkZ973pa" role="2OqNvi">
+                <node concept="1bVj0M" id="54jQkZ973pb" role="23t8la">
+                  <node concept="37vLTG" id="54jQkZ973pc" role="1bW2Oz">
+                    <property role="TrG5h" value="elem" />
+                    <node concept="17QB3L" id="54jQkZ973pd" role="1tU5fm" />
+                  </node>
+                  <node concept="3clFbS" id="54jQkZ973pe" role="1bW5cS">
+                    <node concept="3clFbF" id="54jQkZ973pf" role="3cqZAp">
+                      <node concept="2OqwBi" id="54jQkZ9741U" role="3clFbG">
+                        <node concept="37vLTw" id="54jQkZ973Cq" role="2Oq$k0">
+                          <ref role="3cqZAo" node="54jQkZ973pc" resolve="elem" />
+                        </node>
+                        <node concept="liA8E" id="54jQkZ974dr" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="54jQkZ974jD" role="3cqZAp">
+          <node concept="2OqwBi" id="54jQkZ974AB" role="3clFbG">
+            <node concept="10M0yZ" id="54jQkZ974kU" role="2Oq$k0">
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+            </node>
+            <node concept="liA8E" id="54jQkZ974QD" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(int)" resolve="println" />
+              <node concept="2OqwBi" id="54jQkZ975LA" role="37wK5m">
+                <node concept="37vLTw" id="54jQkZ9756j" role="2Oq$k0">
+                  <ref role="3cqZAo" node="54jQkZ973p7" resolve="byLength" />
+                </node>
+                <node concept="34oBXx" id="54jQkZ976k4" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="54jQkZ9dI_W" role="3cqZAp">
+          <node concept="3cpWsn" id="54jQkZ9dI_X" role="3cpWs9">
+            <property role="TrG5h" value="isVowel" />
+            <node concept="3rvAFt" id="54jQkZ9dHNo" role="1tU5fm">
+              <node concept="10P_77" id="54jQkZ9dHNx" role="3rvQeY" />
+              <node concept="A3Dl8" id="54jQkZ9dHNy" role="3rvSg0">
+                <node concept="17QB3L" id="54jQkZ9dHNz" role="A3Ik2" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="54jQkZ9dI_Y" role="33vP2m">
+              <node concept="37vLTw" id="54jQkZ9dI_Z" role="2Oq$k0">
+                <ref role="3cqZAo" node="54jQkZ8Xz$C" resolve="numbers" />
+              </node>
+              <node concept="2pSdkF" id="54jQkZ9dIA0" role="2OqNvi">
+                <node concept="1bVj0M" id="54jQkZ9dIA1" role="23t8la">
+                  <node concept="3clFbS" id="54jQkZ9dIA2" role="1bW5cS">
+                    <node concept="3clFbF" id="54jQkZ9dIA3" role="3cqZAp">
+                      <node concept="2OqwBi" id="54jQkZ9dIA4" role="3clFbG">
+                        <node concept="17RM3I" id="54jQkZ9dIA5" role="2Oq$k0">
+                          <node concept="37vLTw" id="54jQkZ9dIA6" role="17RM3D">
+                            <ref role="3cqZAo" node="54jQkZ9dIAa" resolve="it" />
+                          </node>
+                          <node concept="3cmrfG" id="54jQkZ9dIA7" role="17RM3F">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="54jQkZ9dIA8" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
+                          <node concept="Xl_RD" id="54jQkZ9dIA9" role="37wK5m">
+                            <property role="Xl_RC" value="[AEIOU]" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="54jQkZ9dIAa" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="54jQkZ9dIAb" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="54jQkZ9dJzw" role="3cqZAp">
+          <node concept="2OqwBi" id="54jQkZ9dJUt" role="3clFbG">
+            <node concept="10M0yZ" id="54jQkZ9dJBA" role="2Oq$k0">
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+            </node>
+            <node concept="liA8E" id="54jQkZ9dKg6" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.Object)" resolve="println" />
+              <node concept="3EllGN" id="54jQkZ9dM$f" role="37wK5m">
+                <node concept="3clFbT" id="54jQkZ9dMKs" role="3ElVtu">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="37vLTw" id="54jQkZ9dKr8" role="3ElQJh">
+                  <ref role="3cqZAo" node="54jQkZ9dI_X" resolve="isVowel" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="54jQkZ9flBs" role="3cqZAp">
+          <node concept="2OqwBi" id="54jQkZ9flM6" role="3clFbG">
+            <node concept="37vLTw" id="54jQkZ9flBq" role="2Oq$k0">
+              <ref role="3cqZAo" node="54jQkZ8Xz$C" resolve="numbers" />
+            </node>
+            <node concept="3zZkjj" id="54jQkZ9fm9E" role="2OqNvi">
+              <node concept="1bVj0M" id="54jQkZ9fm9G" role="23t8la">
+                <node concept="3clFbS" id="54jQkZ9fm9H" role="1bW5cS">
+                  <node concept="3clFbF" id="54jQkZ9fmjz" role="3cqZAp">
+                    <node concept="3eOVzh" id="54jQkZ9foYp" role="3clFbG">
+                      <node concept="3cmrfG" id="54jQkZ9foY$" role="3uHU7w">
+                        <property role="3cmrfH" value="5" />
+                      </node>
+                      <node concept="2OqwBi" id="54jQkZ9fmJT" role="3uHU7B">
+                        <node concept="37vLTw" id="54jQkZ9fmjy" role="2Oq$k0">
+                          <ref role="3cqZAo" node="54jQkZ9fm9I" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="54jQkZ9fnbj" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="54jQkZ9fm9I" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="54jQkZ9fm9J" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="54jQkZ8XzyI" role="1B3o_S" />
+      <node concept="3cqZAl" id="54jQkZ8XzyV" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="54jQkZ8XvIV" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/de.itemis.mps.baseLanguageExtensions.mpl
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/de.itemis.mps.baseLanguageExtensions.mpl
@@ -26,6 +26,7 @@
       <external-templates />
       <languageVersions>
         <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+        <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
         <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
         <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
         <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
@@ -41,6 +42,7 @@
         <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
         <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
         <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+        <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
       </languageVersions>
       <dependencyVersions>
         <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:e9626ecf-a0aa-465d-b5a3-3e84bb263ef5(de.itemis.mps.baseLanguageExtensions.generator.templates@generator)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="4" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
   </languages>
   <imports>
     <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" />
     <import index="96gm" ref="r:2eaed950-3bc1-47cd-9b02-e917ff994d7c(de.itemis.mps.baseLanguageExtensions.runtime)" />
-    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="tp2g" ref="r:00000000-0000-4000-0000-011c89590334(jetbrains.mps.baseLanguage.closures.constraints)" />
     <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" implicit="true" />
+    <import index="tp2c" ref="r:00000000-0000-4000-0000-011c89590338(jetbrains.mps.baseLanguage.closures.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -24,6 +29,11 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -37,10 +47,21 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
       <concept id="1114706874351" name="jetbrains.mps.lang.generator.structure.CopySrcNodeMacro" flags="ln" index="29HgVG">
         <child id="1168024447342" name="sourceNodeQuery" index="3NFExx" />
+      </concept>
+      <concept id="1114729360583" name="jetbrains.mps.lang.generator.structure.CopySrcListMacro" flags="ln" index="2b32R4">
+        <child id="1168278589236" name="sourceNodesQuery" index="2P8S$" />
       </concept>
       <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
         <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
@@ -48,9 +69,18 @@
       <concept id="1177093525992" name="jetbrains.mps.lang.generator.structure.InlineTemplate_RuleConsequence" flags="lg" index="gft3U">
         <child id="1177093586806" name="templateNode" index="gfFT$" />
       </concept>
+      <concept id="1112730859144" name="jetbrains.mps.lang.generator.structure.TemplateSwitch" flags="ig" index="jVnub">
+        <child id="1168558750579" name="defaultConsequence" index="jxRDz" />
+        <child id="1167340453568" name="reductionMappingRule" index="3aUrZf" />
+      </concept>
+      <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ng" index="v9R3L">
+        <reference id="1722980698497626483" name="template" index="v9R2y" />
+        <child id="1722980698497626405" name="actualArgument" index="v9R3O" />
+      </concept>
       <concept id="1167168920554" name="jetbrains.mps.lang.generator.structure.BaseMappingRule_Condition" flags="in" index="30G5F_" />
       <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
       <concept id="1167169308231" name="jetbrains.mps.lang.generator.structure.BaseMappingRule" flags="ng" index="30H$t8">
+        <property id="1167272244852" name="applyToConceptInheritors" index="36QftV" />
         <reference id="1167169349424" name="applicableConcept" index="30HIoZ" />
         <child id="1167169362365" name="conditionFunction" index="30HLyM" />
       </concept>
@@ -60,8 +90,18 @@
       <concept id="1167327847730" name="jetbrains.mps.lang.generator.structure.Reduction_MappingRule" flags="lg" index="3aamgX">
         <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
       </concept>
+      <concept id="982871510064032177" name="jetbrains.mps.lang.generator.structure.IParameterizedTemplate" flags="ng" index="1s_3nv">
+        <child id="982871510064032342" name="parameter" index="1s_3oS" />
+      </concept>
+      <concept id="982871510068000147" name="jetbrains.mps.lang.generator.structure.TemplateSwitchMacro" flags="lg" index="1sPUBX">
+        <child id="982871510068000158" name="sourceNodeQuery" index="1sPUBK" />
+      </concept>
       <concept id="1167756080639" name="jetbrains.mps.lang.generator.structure.PropertyMacro_GetPropertyValue" flags="in" index="3zFVjK" />
       <concept id="1167945743726" name="jetbrains.mps.lang.generator.structure.IfMacro_Condition" flags="in" index="3IZrLx" />
+      <concept id="1167951910403" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodesQuery" flags="in" index="3JmXsc" />
+      <concept id="1805153994415891174" name="jetbrains.mps.lang.generator.structure.TemplateParameterDeclaration" flags="ng" index="1N15co">
+        <child id="1805153994415893199" name="type" index="1N15GL" />
+      </concept>
       <concept id="1168024337012" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodeQuery" flags="in" index="3NFfHV" />
       <concept id="1118773211870" name="jetbrains.mps.lang.generator.structure.IfMacro" flags="ln" index="1W57fq">
         <child id="1194989344771" name="alternativeConsequence" index="UU_$l" />
@@ -70,8 +110,12 @@
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
@@ -88,11 +132,17 @@
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -105,6 +155,14 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
+        <child id="1225711182005" name="list" index="1y566C" />
+        <child id="1225711191269" name="index" index="1y58nS" />
       </concept>
     </language>
   </registry>
@@ -355,6 +413,218 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="54jQkZ97WKE" role="3acgRq">
+      <ref role="30HIoZ" to="tpee:hqOqwz4" resolve="DotExpression" />
+      <node concept="gft3U" id="54jQkZ986e1" role="1lVwrX">
+        <node concept="2YIFZM" id="54jQkZ986eg" role="gfFT$">
+          <ref role="37wK5l" to="96gm:54jQkZ8QoHD" resolve="apply" />
+          <ref role="1Pybhc" to="96gm:54jQkZ8QoGe" resolve="GroupByOperationUtil" />
+          <node concept="10Nm6u" id="54jQkZ9fwtV" role="37wK5m">
+            <node concept="29HgVG" id="54jQkZ9fwz6" role="lGtFl">
+              <node concept="3NFfHV" id="54jQkZ9fwz7" role="3NFExx">
+                <node concept="3clFbS" id="54jQkZ9fwz8" role="2VODD2">
+                  <node concept="3clFbF" id="54jQkZ9fwze" role="3cqZAp">
+                    <node concept="2OqwBi" id="54jQkZ9fwz9" role="3clFbG">
+                      <node concept="3TrEf2" id="54jQkZ9fwzc" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+                      </node>
+                      <node concept="30H73N" id="54jQkZ9fwzd" role="2Oq$k0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="10Nm6u" id="54jQkZ9fKdF" role="37wK5m">
+            <node concept="1sPUBX" id="54jQkZ9fKkf" role="lGtFl">
+              <ref role="v9R2y" node="54jQkZ9fKWX" resolve="GroupByOperation" />
+              <node concept="2OqwBi" id="54jQkZ9fMYQ" role="v9R3O">
+                <node concept="1PxgMI" id="54jQkZ9fMFx" role="2Oq$k0">
+                  <node concept="chp4Y" id="54jQkZ9fMJ0" role="3oSUPX">
+                    <ref role="cht4Q" to="pkab:54jQkZ8WKL$" resolve="GroupByOperation" />
+                  </node>
+                  <node concept="2OqwBi" id="54jQkZ9fLlS" role="1m5AlR">
+                    <node concept="30H73N" id="54jQkZ9fL5F" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="54jQkZ9fLY9" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="54jQkZ9fNFp" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                </node>
+              </node>
+              <node concept="3NFfHV" id="54jQkZ9ghak" role="1sPUBK">
+                <node concept="3clFbS" id="54jQkZ9ghal" role="2VODD2">
+                  <node concept="3clFbF" id="54jQkZ9ghe5" role="3cqZAp">
+                    <node concept="2OqwBi" id="54jQkZ9gi8_" role="3clFbG">
+                      <node concept="1PxgMI" id="54jQkZ9ghTt" role="2Oq$k0">
+                        <node concept="chp4Y" id="54jQkZ9ghUr" role="3oSUPX">
+                          <ref role="cht4Q" to="pkab:54jQkZ8WKL$" resolve="GroupByOperation" />
+                        </node>
+                        <node concept="2OqwBi" id="54jQkZ9ghtg" role="1m5AlR">
+                          <node concept="30H73N" id="54jQkZ9ghe4" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="54jQkZ9ghIq" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="54jQkZ9giOQ" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="54jQkZ988j5" role="30HLyM">
+        <node concept="3clFbS" id="54jQkZ988j6" role="2VODD2">
+          <node concept="3clFbF" id="54jQkZ988qz" role="3cqZAp">
+            <node concept="2OqwBi" id="54jQkZ989_2" role="3clFbG">
+              <node concept="2OqwBi" id="54jQkZ988Ia" role="2Oq$k0">
+                <node concept="30H73N" id="54jQkZ988qy" role="2Oq$k0" />
+                <node concept="3TrEf2" id="54jQkZ988Ze" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="54jQkZ989UC" role="2OqNvi">
+                <node concept="chp4Y" id="54jQkZ989Xr" role="cj9EA">
+                  <ref role="cht4Q" to="pkab:54jQkZ8WKL$" resolve="GroupByOperation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="jVnub" id="54jQkZ9fKWX">
+    <property role="TrG5h" value="GroupByOperation" />
+    <node concept="1N15co" id="54jQkZ9fKWY" role="1s_3oS">
+      <property role="TrG5h" value="operation" />
+      <node concept="3Tqbb2" id="54jQkZ9fKXa" role="1N15GL">
+        <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+      </node>
+    </node>
+    <node concept="3aamgX" id="54jQkZ9fNRG" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+      <node concept="gft3U" id="54jQkZ9g988" role="1lVwrX">
+        <node concept="1bVj0M" id="54jQkZ9grof" role="gfFT$">
+          <node concept="37vLTG" id="54jQkZ9groL" role="1bW2Oz">
+            <property role="TrG5h" value="it" />
+            <node concept="3uibUv" id="54jQkZ9grpo" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+              <node concept="29HgVG" id="54jQkZ9grrh" role="lGtFl">
+                <node concept="3NFfHV" id="54jQkZ9gAC7" role="3NFExx">
+                  <node concept="3clFbS" id="54jQkZ9gAC8" role="2VODD2">
+                    <node concept="3clFbF" id="54jQkZ9gAR4" role="3cqZAp">
+                      <node concept="2YIFZM" id="54jQkZ9gBYT" role="3clFbG">
+                        <ref role="37wK5l" to="tp2g:hwak6Ex" resolve="copyTypeRecursively" />
+                        <ref role="1Pybhc" to="tp2g:hv18zCR" resolve="ClassifierTypeUtil" />
+                        <node concept="2YIFZM" id="54jQkZ9gDaE" role="37wK5m">
+                          <ref role="37wK5l" to="tp2g:hv18AMC" resolve="getTypeCoercedToClassifierType" />
+                          <ref role="1Pybhc" to="tp2g:hv18zCR" resolve="ClassifierTypeUtil" />
+                          <node concept="2OqwBi" id="54jQkZ9hwee" role="37wK5m">
+                            <node concept="2OqwBi" id="54jQkZ9hkJ3" role="2Oq$k0">
+                              <node concept="1PxgMI" id="54jQkZ9h4c$" role="2Oq$k0">
+                                <node concept="chp4Y" id="54jQkZ9h4zP" role="3oSUPX">
+                                  <ref role="cht4Q" to="tp2c:U7sbC7HC1h" resolve="ClosureLiteralType" />
+                                </node>
+                                <node concept="2OqwBi" id="3612de$tQry" role="1m5AlR">
+                                  <node concept="30H73N" id="3612de$tQrz" role="2Oq$k0" />
+                                  <node concept="3JvlWi" id="3612de$tQr$" role="2OqNvi" />
+                                </node>
+                              </node>
+                              <node concept="3Tsc0h" id="54jQkZ9hlm3" role="2OqNvi">
+                                <ref role="3TtcxE" to="tp2c:htajw4W" resolve="parameterType" />
+                              </node>
+                            </node>
+                            <node concept="1uHKPH" id="54jQkZ9hDFi" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="54jQkZ9grog" role="1bW5cS">
+            <node concept="3clFbF" id="54jQkZ9grrZ" role="3cqZAp">
+              <node concept="10Nm6u" id="54jQkZ9grrY" role="3clFbG" />
+              <node concept="2b32R4" id="54jQkZ9grtV" role="lGtFl">
+                <node concept="3JmXsc" id="54jQkZ9grtW" role="2P8S$">
+                  <node concept="3clFbS" id="54jQkZ9grtX" role="2VODD2">
+                    <node concept="3clFbF" id="54jQkZ9grxP" role="3cqZAp">
+                      <node concept="2OqwBi" id="54jQkZ9gsEo" role="3clFbG">
+                        <node concept="2OqwBi" id="54jQkZ9grTO" role="2Oq$k0">
+                          <node concept="30H73N" id="54jQkZ9grxO" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="54jQkZ9gsl3" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tp2c:htbW58J" resolve="body" />
+                          </node>
+                        </node>
+                        <node concept="3Tsc0h" id="54jQkZ9gtBb" role="2OqNvi">
+                          <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="54jQkZ9fNVy" role="30HLyM">
+        <node concept="3clFbS" id="54jQkZ9fNVz" role="2VODD2">
+          <node concept="3clFbF" id="54jQkZ9fO0o" role="3cqZAp">
+            <node concept="1Wc70l" id="54jQkZ9g42P" role="3clFbG">
+              <node concept="2OqwBi" id="54jQkZ9g5Rp" role="3uHU7w">
+                <node concept="1y4W85" id="54jQkZ9g5qE" role="2Oq$k0">
+                  <node concept="3cmrfG" id="54jQkZ9g5xw" role="1y58nS">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                  <node concept="2OqwBi" id="54jQkZ9g4oe" role="1y566C">
+                    <node concept="30H73N" id="54jQkZ9g45j" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="54jQkZ9g4vf" role="2OqNvi">
+                      <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1mIQ4w" id="54jQkZ9g6EK" role="2OqNvi">
+                  <node concept="chp4Y" id="54jQkZ9g8gt" role="cj9EA">
+                    <ref role="cht4Q" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbC" id="54jQkZ9g3lT" role="3uHU7B">
+                <node concept="2OqwBi" id="54jQkZ9fVmo" role="3uHU7B">
+                  <node concept="2OqwBi" id="54jQkZ9fOpL" role="2Oq$k0">
+                    <node concept="30H73N" id="54jQkZ9fO0n" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="54jQkZ9fOMq" role="2OqNvi">
+                      <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                    </node>
+                  </node>
+                  <node concept="34oBXx" id="54jQkZ9g1zZ" role="2OqNvi" />
+                </node>
+                <node concept="3cmrfG" id="54jQkZ9g3R_" role="3uHU7w">
+                  <property role="3cmrfH" value="1" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="gft3U" id="54jQkZ9g94P" role="jxRDz">
+      <node concept="10Nm6u" id="54jQkZ9g97V" role="gfFT$">
+        <node concept="29HgVG" id="54jQkZ9g984" role="lGtFl" />
       </node>
     </node>
   </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
@@ -15,6 +15,7 @@
     <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" implicit="true" />
     <import index="tp2c" ref="r:00000000-0000-4000-0000-011c89590338(jetbrains.mps.baseLanguage.closures.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -548,6 +549,37 @@
                             <node concept="1uHKPH" id="54jQkZ9hDFi" role="2OqNvi" />
                           </node>
                         </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="17Uvod" id="2oJmO5LUoUC" role="lGtFl">
+              <property role="2qtEX9" value="name" />
+              <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+              <node concept="3zFVjK" id="2oJmO5LUoUD" role="3zH0cK">
+                <node concept="3clFbS" id="2oJmO5LUoUE" role="2VODD2">
+                  <node concept="3clFbF" id="2oJmO5LUpuQ" role="3cqZAp">
+                    <node concept="2OqwBi" id="2oJmO5LUz$Q" role="3clFbG">
+                      <node concept="1PxgMI" id="2oJmO5LUz43" role="2Oq$k0">
+                        <node concept="chp4Y" id="2oJmO5LUz7f" role="3oSUPX">
+                          <ref role="cht4Q" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
+                        </node>
+                        <node concept="1y4W85" id="2oJmO5LUwtJ" role="1m5AlR">
+                          <node concept="3cmrfG" id="2oJmO5LUwz4" role="1y58nS">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="2OqwBi" id="2oJmO5LUpTD" role="1y566C">
+                            <node concept="30H73N" id="2oJmO5LUpuP" role="2Oq$k0" />
+                            <node concept="3Tsc0h" id="2oJmO5LUqoj" role="2OqNvi">
+                              <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3TrcHB" id="2oJmO5LU_Wf" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.actions.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.actions.mps
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:f2a647e2-c8f4-470a-b1f2-04d25cd1ccaf(de.itemis.mps.baseLanguageExtensions.actions)">
+  <persistence version="9" />
+  <languages>
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
+    <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tp2c" ref="r:00000000-0000-4000-0000-011c89590338(jetbrains.mps.baseLanguage.closures.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+    </language>
+    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="767145758118872833" name="jetbrains.mps.lang.actions.structure.NF_LinkList_AddNewChildOperation" flags="nn" index="2DeJg1" />
+      <concept id="767145758118872830" name="jetbrains.mps.lang.actions.structure.NF_Link_SetNewChildOperation" flags="nn" index="2DeJnY" />
+      <concept id="1158700664498" name="jetbrains.mps.lang.actions.structure.NodeFactories" flags="ng" index="37WguZ">
+        <child id="1158700779049" name="nodeFactory" index="37WGs$" />
+      </concept>
+      <concept id="1158700725281" name="jetbrains.mps.lang.actions.structure.NodeFactory" flags="ig" index="37WvkG">
+        <reference id="1158700943156" name="applicableConcept" index="37XkoT" />
+        <child id="1158701448518" name="setupFunction" index="37ZfLb" />
+      </concept>
+      <concept id="1158701162220" name="jetbrains.mps.lang.actions.structure.NodeSetupFunction" flags="in" index="37Y9Zx" />
+      <concept id="5584396657084912703" name="jetbrains.mps.lang.actions.structure.NodeSetupFunction_NewNode" flags="nn" index="1r4Lsj" />
+      <concept id="5584396657084920413" name="jetbrains.mps.lang.actions.structure.NodeSetupFunction_SampleNode" flags="nn" index="1r4N5L" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
+        <child id="1140725362529" name="linkTarget" index="2oxUTC" />
+      </concept>
+      <concept id="1138661924179" name="jetbrains.mps.lang.smodel.structure.Property_SetOperation" flags="nn" index="tyxLq">
+        <child id="1138662048170" name="value" index="tz02z" />
+      </concept>
+      <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC">
+        <reference id="1139880128956" name="concept" index="1A9B2P" />
+      </concept>
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
+        <reference id="1139877738879" name="concept" index="1A0vxQ" />
+      </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="37WguZ" id="54jQkZ97q5g">
+    <property role="TrG5h" value="groupBy_operation" />
+    <property role="3GE5qa" value="groupByOperation" />
+    <node concept="37WvkG" id="54jQkZ97q5h" role="37WGs$">
+      <ref role="37XkoT" to="pkab:54jQkZ8WKL$" resolve="GroupByOperation" />
+      <node concept="37Y9Zx" id="54jQkZ97q5i" role="37ZfLb">
+        <node concept="3clFbS" id="54jQkZ97q5j" role="2VODD2">
+          <node concept="3clFbJ" id="6UAZX9kbG2k" role="3cqZAp">
+            <node concept="3clFbS" id="6UAZX9kbG2l" role="3clFbx">
+              <node concept="3clFbF" id="6UAZX9kbGjQ" role="3cqZAp">
+                <node concept="2OqwBi" id="6UAZX9kbOgC" role="3clFbG">
+                  <node concept="2OqwBi" id="6UAZX9kbGjS" role="2Oq$k0">
+                    <node concept="1r4Lsj" id="6UAZX9kbGjR" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="6UAZX9kbOgB" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                    </node>
+                  </node>
+                  <node concept="2oxUTD" id="6UAZX9kbOgG" role="2OqNvi">
+                    <node concept="2OqwBi" id="6UAZX9kbOh2" role="2oxUTC">
+                      <node concept="2OqwBi" id="6UAZX9kbOgV" role="2Oq$k0">
+                        <node concept="1PxgMI" id="6UAZX9kbOgR" role="2Oq$k0">
+                          <node concept="1r4N5L" id="6UAZX9kbOgJ" role="1m5AlR" />
+                          <node concept="chp4Y" id="714IaVdGYEc" role="3oSUPX">
+                            <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="6UAZX9kbOh0" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                        </node>
+                      </node>
+                      <node concept="3YRAZt" id="6UAZX9kbOh7" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6UAZX9kbG2p" role="3clFbw">
+              <node concept="1r4N5L" id="6UAZX9kbG2o" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="6UAZX9kbGjJ" role="2OqNvi">
+                <node concept="chp4Y" id="6UAZX9kbGjL" role="cj9EA">
+                  <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                </node>
+              </node>
+            </node>
+            <node concept="9aQIb" id="6UAZX9kbGjM" role="9aQIa">
+              <node concept="3clFbS" id="6UAZX9kbGjN" role="9aQI4">
+                <node concept="3cpWs8" id="hOYLEwW" role="3cqZAp">
+                  <node concept="3cpWsn" id="hOYLEwX" role="3cpWs9">
+                    <property role="TrG5h" value="sel" />
+                    <node concept="3Tqbb2" id="hOYLEwY" role="1tU5fm">
+                      <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+                    </node>
+                    <node concept="2OqwBi" id="hOYLEwZ" role="33vP2m">
+                      <node concept="1r4Lsj" id="hOYLEx0" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="hOYLEx1" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="hOYLF7B" role="3cqZAp">
+                  <node concept="3clFbS" id="hOYLF7C" role="3clFbx">
+                    <node concept="3clFbF" id="hOYLGs8" role="3cqZAp">
+                      <node concept="37vLTI" id="hOYLGMl" role="3clFbG">
+                        <node concept="2OqwBi" id="hOYLJR3" role="37vLTx">
+                          <node concept="2OqwBi" id="hOYLIy4" role="2Oq$k0">
+                            <node concept="1r4Lsj" id="hOYLIgR" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="hOYLJIO" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                            </node>
+                          </node>
+                          <node concept="2DeJnY" id="5wUAOoBBjpf" role="2OqNvi">
+                            <ref role="1A9B2P" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="3GM_nagTxRn" role="37vLTJ">
+                          <ref role="3cqZAo" node="hOYLEwX" resolve="sel" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="hOYLFmB" role="3clFbw">
+                    <node concept="37vLTw" id="3GM_nagTvxd" role="2Oq$k0">
+                      <ref role="3cqZAo" node="hOYLEwX" resolve="sel" />
+                    </node>
+                    <node concept="3w_OXm" id="hOYLFQD" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="hOYM1wv" role="3cqZAp">
+                  <node concept="3cpWsn" id="hOYM1ww" role="3cpWs9">
+                    <property role="TrG5h" value="pd" />
+                    <node concept="3Tqbb2" id="hOYM1wx" role="1tU5fm">
+                      <ref role="ehGHo" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
+                    </node>
+                    <node concept="2OqwBi" id="hOYM1wy" role="33vP2m">
+                      <node concept="2OqwBi" id="hOYM1wz" role="2Oq$k0">
+                        <node concept="1PxgMI" id="hOYM1w$" role="2Oq$k0">
+                          <node concept="37vLTw" id="3GM_nagTBT7" role="1m5AlR">
+                            <ref role="3cqZAo" node="hOYLEwX" resolve="sel" />
+                          </node>
+                          <node concept="chp4Y" id="714IaVdGYD$" role="3oSUPX">
+                            <ref role="cht4Q" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                          </node>
+                        </node>
+                        <node concept="3Tsc0h" id="hOYM1wA" role="2OqNvi">
+                          <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                        </node>
+                      </node>
+                      <node concept="2DeJg1" id="5wUAOoBBjpK" role="2OqNvi">
+                        <ref role="1A0vxQ" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="hOYM2aC" role="3cqZAp">
+                  <node concept="2OqwBi" id="hOYM32Q" role="3clFbG">
+                    <node concept="2OqwBi" id="hOYM2e8" role="2Oq$k0">
+                      <node concept="37vLTw" id="3GM_nagT_Pf" role="2Oq$k0">
+                        <ref role="3cqZAo" node="hOYM1ww" resolve="pd" />
+                      </node>
+                      <node concept="3TrcHB" id="hOYM2GZ" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                    <node concept="tyxLq" id="hOYM3f2" role="2OqNvi">
+                      <node concept="Xl_RD" id="hOYM3Ci" role="tz02z">
+                        <property role="Xl_RC" value="it" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
@@ -120,5 +120,13 @@
     <property role="3GE5qa" value="zipOperation" />
     <ref role="1TJDcQ" to="tp2q:h856pF2" resolve="BinaryOperation" />
   </node>
+  <node concept="1TIwiD" id="54jQkZ8WKL$">
+    <property role="EcuMT" value="5842252078326680676" />
+    <property role="TrG5h" value="GroupByOperation" />
+    <property role="34LRSv" value="groupBy" />
+    <property role="R4oN_" value="identify groups of elements" />
+    <property role="3GE5qa" value="groupByOperation" />
+    <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+  </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
@@ -37,6 +37,7 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1068431790189" name="jetbrains.mps.baseLanguage.structure.Type" flags="in" index="33vP2l" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -72,6 +73,12 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+        <child id="1199542501692" name="parameterType" index="1ajw0F" />
+      </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="1196350785110" name="jetbrains.mps.lang.quotation.structure.AbstractAntiquotation" flags="ng" index="2c44t0">
@@ -176,6 +183,10 @@
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
+        <child id="1197683466920" name="keyType" index="3rvQeY" />
+        <child id="1197683475734" name="valueType" index="3rvSg0" />
       </concept>
     </language>
   </registry>
@@ -718,6 +729,83 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="1YbPZF" id="54jQkZ8XvFc">
+    <property role="TrG5h" value="typeof_GroupByOperation" />
+    <property role="3GE5qa" value="groupByOperation" />
+    <node concept="3clFbS" id="54jQkZ8XvFd" role="18ibNy">
+      <node concept="1ZxtTE" id="54jQkZ929lm" role="3cqZAp">
+        <property role="TrG5h" value="paramType" />
+      </node>
+      <node concept="1ZxtTE" id="54jQkZ929lY" role="3cqZAp">
+        <property role="TrG5h" value="keyType" />
+      </node>
+      <node concept="3clFbF" id="54jQkZ929oW" role="3cqZAp">
+        <node concept="2YIFZM" id="54jQkZ929Bk" role="3clFbG">
+          <ref role="37wK5l" to="tp2v:4Iwp2tSBzXf" resolve="inferInternalOperation" />
+          <ref role="1Pybhc" to="tp2v:4Iwp2tSBvWa" resolve="OperationInference" />
+          <node concept="1YBJjd" id="54jQkZ929BU" role="37wK5m">
+            <ref role="1YBMHb" node="54jQkZ8XvFf" resolve="groupByOperation" />
+          </node>
+          <node concept="1Z$b5t" id="54jQkZ929IT" role="37wK5m">
+            <ref role="1Z$eMM" node="54jQkZ929lm" resolve="paramType" />
+          </node>
+          <node concept="2c44tf" id="34jUqC_VR5$" role="37wK5m">
+            <node concept="1ajhzC" id="34jUqC_VR5_" role="2c44tc">
+              <node concept="33vP2l" id="34jUqC_VR5A" role="1ajw0F">
+                <node concept="2c44te" id="34jUqC_VR5B" role="lGtFl">
+                  <node concept="1Z$b5t" id="34jUqC_VR5C" role="2c44t1">
+                    <ref role="1Z$eMM" node="54jQkZ929lm" resolve="paramType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="33vP2l" id="54jQkZ929Qy" role="1ajl9A">
+                <node concept="2c44te" id="54jQkZ929Qz" role="lGtFl">
+                  <node concept="1Z$b5t" id="54jQkZ929Q$" role="2c44t1">
+                    <ref role="1Z$eMM" node="54jQkZ929lY" resolve="keyType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1Z5TYs" id="54jQkZ92as2" role="3cqZAp">
+        <node concept="mw_s8" id="54jQkZ92aFm" role="1ZfhKB">
+          <node concept="2c44tf" id="54jQkZ92aHD" role="mwGJk">
+            <node concept="3rvAFt" id="54jQkZ92aIn" role="2c44tc">
+              <node concept="33vP2l" id="54jQkZ92aIo" role="3rvQeY">
+                <node concept="2c44te" id="54jQkZ92aRp" role="lGtFl">
+                  <node concept="1Z$b5t" id="54jQkZ92aRx" role="2c44t1">
+                    <ref role="1Z$eMM" node="54jQkZ929lY" resolve="keyType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="A3Dl8" id="54jQkZ92b18" role="3rvSg0">
+                <node concept="33vP2l" id="54jQkZ92b19" role="A3Ik2">
+                  <node concept="2c44te" id="54jQkZ92b1l" role="lGtFl">
+                    <node concept="1Z$b5t" id="54jQkZ92b1t" role="2c44t1">
+                      <ref role="1Z$eMM" node="54jQkZ929lm" resolve="paramType" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="54jQkZ92as5" role="1ZfhK$">
+          <node concept="1Z2H0r" id="54jQkZ92a4M" role="mwGJk">
+            <node concept="1YBJjd" id="54jQkZ92a8c" role="1Z2MuG">
+              <ref role="1YBMHb" node="54jQkZ8XvFf" resolve="groupByOperation" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="54jQkZ8XvFf" role="1YuTPh">
+      <property role="TrG5h" value="groupByOperation" />
+      <ref role="1YaFvo" to="pkab:54jQkZ8WKL$" resolve="GroupByOperation" />
     </node>
   </node>
 </model>

--- a/code/solutions/de.itemis.mps.baseLanguageExtensions.test/de.itemis.mps.baseLanguageExtensions.test.msd
+++ b/code/solutions/de.itemis.mps.baseLanguageExtensions.test/de.itemis.mps.baseLanguageExtensions.test.msd
@@ -14,6 +14,7 @@
   <dependencies>
     <dependency reexport="false">d91eaf6f-a378-467f-9524-0c201ee2e15f(de.itemis.mps.baseLanguageExtensions.runtime)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -28,6 +29,7 @@
   </languageVersions>
   <dependencyVersions>
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
     <module reference="d91eaf6f-a378-467f-9524-0c201ee2e15f(de.itemis.mps.baseLanguageExtensions.runtime)" version="0" />
     <module reference="6f208df3-71dd-4d85-97d4-cc55c1d5b8e4(de.itemis.mps.baseLanguageExtensions.test)" version="0" />
   </dependencyVersions>

--- a/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.groupByOperation@tests.mps
+++ b/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.groupByOperation@tests.mps
@@ -1,0 +1,406 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:6a3a49bf-9631-499b-8ace-84153db69deb(de.itemis.mps.baseLanguageExtensions.test.groupByOperation@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+  </languages>
+  <imports>
+    <import index="urs3" ref="r:fc76aa36-3cff-41c7-b94b-eee0e8341932(jetbrains.mps.internal.collections.runtime)" />
+    <import index="96gm" ref="r:2eaed950-3bc1-47cd-9b02-e917ff994d7c(de.itemis.mps.baseLanguageExtensions.runtime)" />
+    <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+        <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+        <child id="1199542501692" name="parameterType" index="1ajw0F" />
+      </concept>
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171931690126" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethod" flags="ig" index="3s$Bmu">
+        <property id="1171931690128" name="methodName" index="3s$Bm0" />
+      </concept>
+      <concept id="1171931851043" name="jetbrains.mps.baseLanguage.unitTest.structure.BTestCase" flags="ig" index="3s_ewN">
+        <property id="1171931851045" name="testCaseName" index="3s_ewP" />
+        <child id="1171931851044" name="testMethodList" index="3s_ewO" />
+      </concept>
+      <concept id="1171931858461" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethodList" flags="ng" index="3s_gsd">
+        <child id="1171931858462" name="testMethod" index="3s_gse" />
+      </concept>
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="3s_ewN" id="54jQkZ8THzt">
+    <property role="3s_ewP" value="GroupByOperation" />
+    <node concept="3Tm1VV" id="54jQkZ8THzu" role="1B3o_S" />
+    <node concept="3s_gsd" id="54jQkZ8THzv" role="3s_ewO">
+      <node concept="3s$Bmu" id="54jQkZ8THzS" role="3s_gse">
+        <property role="3s$Bm0" value="singleEntryListForAllUniqueKeys" />
+        <node concept="3cqZAl" id="54jQkZ8THzT" role="3clF45" />
+        <node concept="3Tm1VV" id="54jQkZ8THzU" role="1B3o_S" />
+        <node concept="3clFbS" id="54jQkZ8THzV" role="3clF47">
+          <node concept="3cpWs8" id="54jQkZ8TLD2" role="3cqZAp">
+            <node concept="3cpWsn" id="54jQkZ8TLD3" role="3cpWs9">
+              <property role="TrG5h" value="elements" />
+              <node concept="3uibUv" id="54jQkZ8TLD0" role="1tU5fm">
+                <ref role="3uigEE" to="urs3:5Ffu4tBUx5R" resolve="ISequence" />
+                <node concept="17QB3L" id="54jQkZ8TLDc" role="11_B2D" />
+              </node>
+              <node concept="2YIFZM" id="54jQkZ8TN5g" role="33vP2m">
+                <ref role="37wK5l" to="urs3:5Ffu4tBUyJX" resolve="fromArray" />
+                <ref role="1Pybhc" to="urs3:5Ffu4tBUyJF" resolve="ListSequence" />
+                <node concept="Xl_RD" id="54jQkZ8TNte" role="37wK5m">
+                  <property role="Xl_RC" value="One" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8TPzs" role="37wK5m">
+                  <property role="Xl_RC" value="Four" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8TR1$" role="37wK5m">
+                  <property role="Xl_RC" value="Seven" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8TShh" role="37wK5m">
+                  <property role="Xl_RC" value="Hundred" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="54jQkZ8TTk7" role="3cqZAp" />
+          <node concept="3cpWs8" id="54jQkZ8TU_b" role="3cqZAp">
+            <node concept="3cpWsn" id="54jQkZ8TU_c" role="3cpWs9">
+              <property role="TrG5h" value="actual" />
+              <node concept="3uibUv" id="54jQkZ8TU_d" role="1tU5fm">
+                <ref role="3uigEE" to="urs3:5Ffu4tBU$6H" resolve="IMapSequence" />
+              </node>
+              <node concept="2YIFZM" id="54jQkZ8TW8k" role="33vP2m">
+                <ref role="37wK5l" to="96gm:54jQkZ8QoHD" resolve="apply" />
+                <ref role="1Pybhc" to="96gm:54jQkZ8QoGe" resolve="GroupByOperationUtil" />
+                <node concept="37vLTw" id="54jQkZ8TWqj" role="37wK5m">
+                  <ref role="3cqZAo" node="54jQkZ8TLD3" resolve="elements" />
+                </node>
+                <node concept="37vLTw" id="54jQkZ8VNk6" role="37wK5m">
+                  <ref role="3cqZAo" node="54jQkZ8VJJO" resolve="lengthExtractor" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="54jQkZ8U0oQ" role="3cqZAp" />
+          <node concept="3vlDli" id="54jQkZ8U1GF" role="3cqZAp">
+            <node concept="3cmrfG" id="54jQkZ8U2ck" role="3tpDZB">
+              <property role="3cmrfH" value="4" />
+            </node>
+            <node concept="2OqwBi" id="54jQkZ8U2Xl" role="3tpDZA">
+              <node concept="37vLTw" id="54jQkZ8U2wp" role="2Oq$k0">
+                <ref role="3cqZAo" node="54jQkZ8TU_c" resolve="actual" />
+              </node>
+              <node concept="liA8E" id="54jQkZ8U6ck" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Map.size()" resolve="size" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="54jQkZ8U6Kl" role="3cqZAp" />
+          <node concept="3clFbF" id="54jQkZ8U8fV" role="3cqZAp">
+            <node concept="2OqwBi" id="54jQkZ8U9dF" role="3clFbG">
+              <node concept="37vLTw" id="54jQkZ8U8fT" role="2Oq$k0">
+                <ref role="3cqZAo" node="54jQkZ8TU_c" resolve="actual" />
+              </node>
+              <node concept="liA8E" id="54jQkZ8Udsh" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Map.forEach(java.util.function.BiConsumer)" resolve="forEach" />
+                <node concept="1rXfSq" id="54jQkZ8Wh2j" role="37wK5m">
+                  <ref role="37wK5l" node="54jQkZ8VWA9" resolve="valueCountMatcher" />
+                  <node concept="3cmrfG" id="54jQkZ8W_lQ" role="37wK5m">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="54jQkZ8UY3f" role="3s_gse">
+        <property role="3s$Bm0" value="collisionsInKeysProduceCombinedValueSequences" />
+        <node concept="3cqZAl" id="54jQkZ8UY3g" role="3clF45" />
+        <node concept="3Tm1VV" id="54jQkZ8UY3h" role="1B3o_S" />
+        <node concept="3clFbS" id="54jQkZ8UY3i" role="3clF47">
+          <node concept="3cpWs8" id="54jQkZ8UZz$" role="3cqZAp">
+            <node concept="3cpWsn" id="54jQkZ8UZz_" role="3cpWs9">
+              <property role="TrG5h" value="elements" />
+              <node concept="3uibUv" id="54jQkZ8UZzA" role="1tU5fm">
+                <ref role="3uigEE" to="urs3:5Ffu4tBUx5R" resolve="ISequence" />
+                <node concept="17QB3L" id="54jQkZ8UZzB" role="11_B2D" />
+              </node>
+              <node concept="2YIFZM" id="54jQkZ8UZzC" role="33vP2m">
+                <ref role="37wK5l" to="urs3:5Ffu4tBUyJX" resolve="fromArray" />
+                <ref role="1Pybhc" to="urs3:5Ffu4tBUyJF" resolve="ListSequence" />
+                <node concept="Xl_RD" id="54jQkZ8UZzD" role="37wK5m">
+                  <property role="Xl_RC" value="One" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8UZzE" role="37wK5m">
+                  <property role="Xl_RC" value="Six" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8UZzF" role="37wK5m">
+                  <property role="Xl_RC" value="Seven" />
+                </node>
+                <node concept="Xl_RD" id="54jQkZ8UZzG" role="37wK5m">
+                  <property role="Xl_RC" value="Eight" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="54jQkZ8UZzH" role="3cqZAp" />
+          <node concept="3cpWs8" id="54jQkZ8UZzI" role="3cqZAp">
+            <node concept="3cpWsn" id="54jQkZ8UZzJ" role="3cpWs9">
+              <property role="TrG5h" value="actual" />
+              <node concept="3uibUv" id="54jQkZ8UZzK" role="1tU5fm">
+                <ref role="3uigEE" to="urs3:5Ffu4tBU$6H" resolve="IMapSequence" />
+              </node>
+              <node concept="2YIFZM" id="54jQkZ8UZzL" role="33vP2m">
+                <ref role="37wK5l" to="96gm:54jQkZ8QoHD" resolve="apply" />
+                <ref role="1Pybhc" to="96gm:54jQkZ8QoGe" resolve="GroupByOperationUtil" />
+                <node concept="37vLTw" id="54jQkZ8UZzM" role="37wK5m">
+                  <ref role="3cqZAo" node="54jQkZ8UZz_" resolve="elements" />
+                </node>
+                <node concept="37vLTw" id="54jQkZ8VOF0" role="37wK5m">
+                  <ref role="3cqZAo" node="54jQkZ8VJJO" resolve="lengthExtractor" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="54jQkZ8V1WL" role="3cqZAp" />
+          <node concept="3vlDli" id="54jQkZ8V2t6" role="3cqZAp">
+            <node concept="3cmrfG" id="54jQkZ8V2WJ" role="3tpDZB">
+              <property role="3cmrfH" value="2" />
+            </node>
+            <node concept="2OqwBi" id="54jQkZ8V3YC" role="3tpDZA">
+              <node concept="37vLTw" id="54jQkZ8V3pk" role="2Oq$k0">
+                <ref role="3cqZAo" node="54jQkZ8UZzJ" resolve="actual" />
+              </node>
+              <node concept="liA8E" id="54jQkZ8V6D7" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Map.size()" resolve="size" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="54jQkZ8V7yQ" role="3cqZAp" />
+          <node concept="3clFbF" id="54jQkZ8Vf93" role="3cqZAp">
+            <node concept="2OqwBi" id="54jQkZ8Vf94" role="3clFbG">
+              <node concept="37vLTw" id="54jQkZ8Vf95" role="2Oq$k0">
+                <ref role="3cqZAo" node="54jQkZ8UZzJ" resolve="actual" />
+              </node>
+              <node concept="liA8E" id="54jQkZ8Vf96" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Map.forEach(java.util.function.BiConsumer)" resolve="forEach" />
+                <node concept="1rXfSq" id="54jQkZ8WjRt" role="37wK5m">
+                  <ref role="37wK5l" node="54jQkZ8VWA9" resolve="valueCountMatcher" />
+                  <node concept="3cmrfG" id="54jQkZ8Wld6" role="37wK5m">
+                    <property role="3cmrfH" value="2" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="54jQkZ8VJJO" role="jymVt">
+      <property role="TrG5h" value="lengthExtractor" />
+      <node concept="1ajhzC" id="54jQkZ8VGx8" role="1tU5fm">
+        <node concept="10Oyi0" id="54jQkZ8VJJM" role="1ajl9A" />
+        <node concept="17QB3L" id="54jQkZ8VJJL" role="1ajw0F" />
+      </node>
+      <node concept="1bVj0M" id="54jQkZ8VMi4" role="33vP2m">
+        <node concept="3clFbS" id="54jQkZ8VMi6" role="1bW5cS">
+          <node concept="3clFbF" id="54jQkZ8VMol" role="3cqZAp">
+            <node concept="2OqwBi" id="54jQkZ8VMKW" role="3clFbG">
+              <node concept="37vLTw" id="54jQkZ8VMok" role="2Oq$k0">
+                <ref role="3cqZAo" node="54jQkZ8VMj5" resolve="element" />
+              </node>
+              <node concept="liA8E" id="54jQkZ8VNh9" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="37vLTG" id="54jQkZ8VMj5" role="1bW2Oz">
+          <property role="TrG5h" value="element" />
+          <node concept="17QB3L" id="54jQkZ8VMj4" role="1tU5fm" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="54jQkZ8VWA9" role="jymVt">
+      <property role="TrG5h" value="valueCountMatcher" />
+      <node concept="3clFbS" id="54jQkZ8VWAc" role="3clF47">
+        <node concept="3clFbF" id="54jQkZ8W5Rs" role="3cqZAp">
+          <node concept="2ShNRf" id="54jQkZ8Wacy" role="3clFbG">
+            <node concept="YeOm9" id="54jQkZ8Wacz" role="2ShVmc">
+              <node concept="1Y3b0j" id="54jQkZ8Wac$" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <property role="373rjd" value="true" />
+                <ref role="1Y3XeK" to="82uw:~BiConsumer" resolve="BiConsumer" />
+                <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+                <node concept="3Tm1VV" id="54jQkZ8Wac_" role="1B3o_S" />
+                <node concept="3clFb_" id="54jQkZ8WacA" role="jymVt">
+                  <property role="TrG5h" value="accept" />
+                  <node concept="3Tm1VV" id="54jQkZ8WacB" role="1B3o_S" />
+                  <node concept="3cqZAl" id="54jQkZ8WacC" role="3clF45" />
+                  <node concept="37vLTG" id="54jQkZ8WacD" role="3clF46">
+                    <property role="TrG5h" value="p1" />
+                    <node concept="3uibUv" id="54jQkZ8WacE" role="1tU5fm">
+                      <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+                    </node>
+                  </node>
+                  <node concept="37vLTG" id="54jQkZ8WacF" role="3clF46">
+                    <property role="TrG5h" value="p2" />
+                    <node concept="3uibUv" id="54jQkZ8WacG" role="1tU5fm">
+                      <ref role="3uigEE" to="urs3:5Ffu4tBUx5R" resolve="ISequence" />
+                      <node concept="17QB3L" id="54jQkZ8WacH" role="11_B2D" />
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="54jQkZ8WacI" role="3clF47">
+                    <node concept="3vlDli" id="54jQkZ8WacJ" role="3cqZAp">
+                      <node concept="37vLTw" id="54jQkZ8Wdsy" role="3tpDZB">
+                        <ref role="3cqZAo" node="54jQkZ8VZ7k" resolve="count" />
+                      </node>
+                      <node concept="2OqwBi" id="54jQkZ8WacL" role="3tpDZA">
+                        <node concept="37vLTw" id="54jQkZ8WacM" role="2Oq$k0">
+                          <ref role="3cqZAo" node="54jQkZ8WacF" resolve="p2" />
+                        </node>
+                        <node concept="liA8E" id="54jQkZ8WacN" role="2OqNvi">
+                          <ref role="37wK5l" to="urs3:5Ffu4tBUx9j" resolve="count" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="54jQkZ8WacO" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" />
+                  </node>
+                </node>
+                <node concept="3uibUv" id="54jQkZ8WacP" role="2Ghqu4">
+                  <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+                </node>
+                <node concept="3uibUv" id="54jQkZ8WacQ" role="2Ghqu4">
+                  <ref role="3uigEE" to="urs3:5Ffu4tBUx5R" resolve="ISequence" />
+                  <node concept="17QB3L" id="54jQkZ8WacR" role="11_B2D" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="54jQkZ8VSlM" role="3clF45">
+        <ref role="3uigEE" to="82uw:~BiConsumer" resolve="BiConsumer" />
+        <node concept="3uibUv" id="54jQkZ8VUQm" role="11_B2D">
+          <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+        </node>
+        <node concept="3uibUv" id="54jQkZ8VVqA" role="11_B2D">
+          <ref role="3uigEE" to="urs3:5Ffu4tBUx5R" resolve="ISequence" />
+          <node concept="17QB3L" id="54jQkZ8VWA4" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="54jQkZ8VZ7k" role="3clF46">
+        <property role="TrG5h" value="count" />
+        <property role="3TUv4t" value="true" />
+        <node concept="10Oyi0" id="54jQkZ8VZ7j" role="1tU5fm" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.groupByOperation@tests.mps
+++ b/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.groupByOperation@tests.mps
@@ -335,7 +335,7 @@
                 <property role="2bfB8j" value="true" />
                 <property role="373rjd" value="true" />
                 <ref role="1Y3XeK" to="82uw:~BiConsumer" resolve="BiConsumer" />
-                <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+                <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
                 <node concept="3Tm1VV" id="54jQkZ8Wac_" role="1B3o_S" />
                 <node concept="3clFb_" id="54jQkZ8WacA" role="jymVt">
                   <property role="TrG5h" value="accept" />
@@ -370,7 +370,7 @@
                     </node>
                   </node>
                   <node concept="2AHcQZ" id="54jQkZ8WacO" role="2AJF6D">
-                    <ref role="2AI5Lk" to="wyt6:~Override" />
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                   </node>
                 </node>
                 <node concept="3uibUv" id="54jQkZ8WacP" role="2Ghqu4">


### PR DESCRIPTION
## Name
GroupBy Operation on sequences

## Operation Type
Dot Expression

## Use Case
When operating on sequences and you want to identify groups of elements that match the same criteria, or more specifically that return the same element when a certain "bucket-sorting-function" is applied, then groupBy is the correct way. This adds an eagerly evaluated operation on sequences that produces a map, where the keys are the "buckets" identified by the provided function and the values are sequences of elements in the original sequence that returned the respective key. All elements from the original sequence will have a single representation in the resulting map.

## Comments
In most FP languages, a groupBy will not return a "map object", but simply a sequence of tuples. This would have been possible here as well, but given Kotlin uses the map semantics as well, and handling maps in MPS is just more convenient than dealing with sequences of indexed tuples, we adopted the Kotlin semantic here as well.