### PR TITLE
Add sequence operations with index to new BaseLanguage extensions

### DIFF
--- a/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/models/de.itemis.mps.baseLanguageExtensions.runtime.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/models/de.itemis.mps.baseLanguageExtensions.runtime.mps
@@ -46,6 +46,7 @@
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <property id="2523873803623706117" name="isMultiline" index="hSjvv" />
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
@@ -58,6 +59,7 @@
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -114,6 +116,7 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
@@ -130,6 +133,7 @@
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
@@ -184,6 +188,7 @@
       <concept id="1172650591544" name="jetbrains.mps.baseLanguage.collections.structure.SkipOperation" flags="nn" index="7r0gD">
         <child id="1172658456740" name="elementsToSkip" index="7T0AP" />
       </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
         <child id="1224414456414" name="elementType" index="kMuH3" />
         <child id="1224414466839" name="initializer" index="kMx8a" />
@@ -193,6 +198,7 @@
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
@@ -731,27 +737,56 @@
     <node concept="3Tm1VV" id="54jQkZ8QoGf" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="7Ja64GBadPz">
-    <property role="TrG5h" value="SelectWithIndexOperationUtil" />
+    <property role="TrG5h" value="WithIndexOperationUtil" />
     <node concept="2tJIrI" id="7Ja64GBah0u" role="jymVt" />
+    <node concept="2YIFZL" id="7Ja64GBdD1A" role="jymVt">
+      <property role="TrG5h" value="zipWithIntRange" />
+      <node concept="3clFbS" id="7Ja64GBdD1D" role="3clF47">
+        <node concept="3clFbF" id="7Ja64GBdDMO" role="3cqZAp">
+          <node concept="2YIFZM" id="7Ja64GBdDMQ" role="3clFbG">
+            <ref role="37wK5l" node="6vHuLLnJvrd" resolve="zip" />
+            <ref role="1Pybhc" node="6vHuLLnJvpc" resolve="ZipOperatorUtil" />
+            <node concept="37vLTw" id="7Ja64GBdDMR" role="37wK5m">
+              <ref role="3cqZAo" node="7Ja64GBdDKO" resolve="seq" />
+            </node>
+            <node concept="2YIFZM" id="7Ja64GBdDMS" role="37wK5m">
+              <ref role="37wK5l" node="vJfcQmgyHy" resolve="range" />
+              <ref role="1Pybhc" node="vJfcQmguGr" resolve="IntegerSequence" />
+              <node concept="3cmrfG" id="7Ja64GBdDMT" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7Ja64GBdFMs" role="1B3o_S" />
+      <node concept="A3Dl8" id="7Ja64GBdD1d" role="3clF45">
+        <node concept="1LlUBW" id="7Ja64GBdDYk" role="A3Ik2">
+          <node concept="16syzq" id="7Ja64GBdE8n" role="1Lm7xW">
+            <ref role="16sUi3" node="7Ja64GBdDJ5" resolve="T" />
+          </node>
+          <node concept="10Oyi0" id="7Ja64GBdEsx" role="1Lm7xW" />
+        </node>
+      </node>
+      <node concept="16euLQ" id="7Ja64GBdDJ5" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+      <node concept="37vLTG" id="7Ja64GBdDKO" role="3clF46">
+        <property role="TrG5h" value="seq" />
+        <node concept="A3Dl8" id="7Ja64GBdDKM" role="1tU5fm">
+          <node concept="16syzq" id="7Ja64GBdDL$" role="A3Ik2">
+            <ref role="16sUi3" node="7Ja64GBdDJ5" resolve="T" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7Ja64GBdBv1" role="jymVt" />
     <node concept="2YIFZL" id="7Ja64GBadQG" role="jymVt">
       <property role="TrG5h" value="selectWithIndex" />
       <node concept="3clFbS" id="7Ja64GBadQJ" role="3clF47">
         <node concept="3clFbF" id="7Ja64GBadZj" role="3cqZAp">
           <node concept="2OqwBi" id="7Ja64GBaeQV" role="3clFbG">
-            <node concept="2YIFZM" id="7Ja64GBae0F" role="2Oq$k0">
-              <ref role="37wK5l" node="6vHuLLnJvrd" resolve="zip" />
-              <ref role="1Pybhc" node="6vHuLLnJvpc" resolve="ZipOperatorUtil" />
-              <node concept="37vLTw" id="7Ja64GBae4o" role="37wK5m">
-                <ref role="3cqZAo" node="7Ja64GBadT8" resolve="seq" />
-              </node>
-              <node concept="2YIFZM" id="7Ja64GBaejV" role="37wK5m">
-                <ref role="37wK5l" node="vJfcQmgyHy" resolve="range" />
-                <ref role="1Pybhc" node="vJfcQmguGr" resolve="IntegerSequence" />
-                <node concept="3cmrfG" id="7Ja64GBaeC0" role="37wK5m">
-                  <property role="3cmrfH" value="0" />
-                </node>
-              </node>
-            </node>
+            <property role="hSjvv" value="true" />
             <node concept="3$u5V9" id="7Ja64GBafdV" role="2OqNvi">
               <node concept="1bVj0M" id="7Ja64GBafdX" role="23t8la">
                 <node concept="3clFbS" id="7Ja64GBafdY" role="1bW5cS">
@@ -783,6 +818,12 @@
                   <property role="TrG5h" value="it" />
                   <node concept="2jxLKc" id="7Ja64GBafe0" role="1tU5fm" />
                 </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="7Ja64GBdEBt" role="2Oq$k0">
+              <ref role="37wK5l" node="7Ja64GBdD1A" resolve="zipWithIntRange" />
+              <node concept="37vLTw" id="7Ja64GBdEJV" role="37wK5m">
+                <ref role="3cqZAo" node="7Ja64GBadT8" resolve="seq" />
               </node>
             </node>
           </node>
@@ -818,6 +859,179 @@
           <node concept="16syzq" id="7Ja64GBadXi" role="1ajl9A">
             <ref role="16sUi3" node="7Ja64GBadRA" resolve="T2" />
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7Ja64GBdwBR" role="jymVt" />
+    <node concept="2YIFZL" id="7Ja64GBdvMJ" role="jymVt">
+      <property role="TrG5h" value="whereWithIndex" />
+      <node concept="3clFbS" id="7Ja64GBdvMK" role="3clF47">
+        <node concept="3clFbF" id="7Ja64GBdvML" role="3cqZAp">
+          <node concept="2OqwBi" id="7Ja64GBdzVA" role="3clFbG">
+            <property role="hSjvv" value="true" />
+            <node concept="2OqwBi" id="7Ja64GBdvMM" role="2Oq$k0">
+              <property role="hSjvv" value="true" />
+              <node concept="3zZkjj" id="7Ja64GBdyG0" role="2OqNvi">
+                <node concept="1bVj0M" id="7Ja64GBdyG2" role="23t8la">
+                  <node concept="3clFbS" id="7Ja64GBdyG3" role="1bW5cS">
+                    <node concept="3clFbF" id="7Ja64GBdyG4" role="3cqZAp">
+                      <node concept="2Sg_IR" id="7Ja64GBdyG5" role="3clFbG">
+                        <node concept="37vLTw" id="7Ja64GBdyG6" role="2SgG2M">
+                          <ref role="3cqZAo" node="7Ja64GBdvNd" resolve="selector" />
+                        </node>
+                        <node concept="1LFfDK" id="7Ja64GBdyG7" role="2SgHGx">
+                          <node concept="3cmrfG" id="7Ja64GBdyG8" role="1LF_Uc">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="37vLTw" id="7Ja64GBdyG9" role="1LFl5Q">
+                            <ref role="3cqZAo" node="7Ja64GBdyGd" resolve="it" />
+                          </node>
+                        </node>
+                        <node concept="1LFfDK" id="7Ja64GBdyGa" role="2SgHGx">
+                          <node concept="3cmrfG" id="7Ja64GBdyGb" role="1LF_Uc">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                          <node concept="37vLTw" id="7Ja64GBdyGc" role="1LFl5Q">
+                            <ref role="3cqZAo" node="7Ja64GBdyGd" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7Ja64GBdyGd" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7Ja64GBdyGe" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1rXfSq" id="7Ja64GBdF1e" role="2Oq$k0">
+                <ref role="37wK5l" node="7Ja64GBdD1A" resolve="zipWithIntRange" />
+                <node concept="37vLTw" id="7Ja64GBdFbl" role="37wK5m">
+                  <ref role="3cqZAo" node="7Ja64GBdvNa" resolve="seq" />
+                </node>
+              </node>
+            </node>
+            <node concept="3$u5V9" id="7Ja64GBd$y1" role="2OqNvi">
+              <node concept="1bVj0M" id="7Ja64GBd$y3" role="23t8la">
+                <node concept="3clFbS" id="7Ja64GBd$y4" role="1bW5cS">
+                  <node concept="3clFbF" id="7Ja64GBd$MY" role="3cqZAp">
+                    <node concept="1LFfDK" id="7Ja64GBd_pz" role="3clFbG">
+                      <node concept="3cmrfG" id="7Ja64GBd_Cs" role="1LF_Uc">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                      <node concept="37vLTw" id="7Ja64GBd$MX" role="1LFl5Q">
+                        <ref role="3cqZAo" node="7Ja64GBd$y5" resolve="it" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="7Ja64GBd$y5" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="7Ja64GBd$y6" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7Ja64GBdvN5" role="1B3o_S" />
+      <node concept="16euLQ" id="7Ja64GBdvN6" role="16eVyc">
+        <property role="TrG5h" value="T1" />
+      </node>
+      <node concept="A3Dl8" id="7Ja64GBdvN8" role="3clF45">
+        <node concept="16syzq" id="7Ja64GBdvN9" role="A3Ik2">
+          <ref role="16sUi3" node="7Ja64GBdvN6" resolve="T1" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7Ja64GBdvNa" role="3clF46">
+        <property role="TrG5h" value="seq" />
+        <node concept="A3Dl8" id="7Ja64GBdvNb" role="1tU5fm">
+          <node concept="16syzq" id="7Ja64GBdvNc" role="A3Ik2">
+            <ref role="16sUi3" node="7Ja64GBdvN6" resolve="T1" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7Ja64GBdvNd" role="3clF46">
+        <property role="TrG5h" value="selector" />
+        <node concept="1ajhzC" id="7Ja64GBdvNe" role="1tU5fm">
+          <node concept="16syzq" id="7Ja64GBdvNf" role="1ajw0F">
+            <ref role="16sUi3" node="7Ja64GBdvN6" resolve="T1" />
+          </node>
+          <node concept="10Oyi0" id="7Ja64GBdvNg" role="1ajw0F" />
+          <node concept="10P_77" id="7Ja64GBdzB6" role="1ajl9A" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7Ja64GBdx5W" role="jymVt" />
+    <node concept="2YIFZL" id="7Ja64GBdw8k" role="jymVt">
+      <property role="TrG5h" value="forEachWithIndex" />
+      <node concept="3clFbS" id="7Ja64GBdw8l" role="3clF47">
+        <node concept="3clFbF" id="7Ja64GBdw8m" role="3cqZAp">
+          <node concept="2OqwBi" id="7Ja64GBdw8n" role="3clFbG">
+            <property role="hSjvv" value="true" />
+            <node concept="2es0OD" id="7Ja64GBdAM3" role="2OqNvi">
+              <node concept="1bVj0M" id="7Ja64GBdAM5" role="23t8la">
+                <node concept="3clFbS" id="7Ja64GBdAM6" role="1bW5cS">
+                  <node concept="3clFbF" id="7Ja64GBdAM7" role="3cqZAp">
+                    <node concept="2Sg_IR" id="7Ja64GBdAM8" role="3clFbG">
+                      <node concept="37vLTw" id="7Ja64GBdAM9" role="2SgG2M">
+                        <ref role="3cqZAo" node="7Ja64GBdw8M" resolve="selector" />
+                      </node>
+                      <node concept="1LFfDK" id="7Ja64GBdAMa" role="2SgHGx">
+                        <node concept="3cmrfG" id="7Ja64GBdAMb" role="1LF_Uc">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="37vLTw" id="7Ja64GBdAMc" role="1LFl5Q">
+                          <ref role="3cqZAo" node="7Ja64GBdAMg" resolve="it" />
+                        </node>
+                      </node>
+                      <node concept="1LFfDK" id="7Ja64GBdAMd" role="2SgHGx">
+                        <node concept="3cmrfG" id="7Ja64GBdAMe" role="1LF_Uc">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="37vLTw" id="7Ja64GBdAMf" role="1LFl5Q">
+                          <ref role="3cqZAo" node="7Ja64GBdAMg" resolve="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="7Ja64GBdAMg" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="7Ja64GBdAMh" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="7Ja64GBdFvl" role="2Oq$k0">
+              <ref role="37wK5l" node="7Ja64GBdD1A" resolve="zipWithIntRange" />
+              <node concept="37vLTw" id="7Ja64GBdFCa" role="37wK5m">
+                <ref role="3cqZAo" node="7Ja64GBdw8J" resolve="seq" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7Ja64GBdw8E" role="1B3o_S" />
+      <node concept="16euLQ" id="7Ja64GBdw8F" role="16eVyc">
+        <property role="TrG5h" value="T1" />
+      </node>
+      <node concept="3cqZAl" id="7Ja64GBdA1i" role="3clF45" />
+      <node concept="37vLTG" id="7Ja64GBdw8J" role="3clF46">
+        <property role="TrG5h" value="seq" />
+        <node concept="A3Dl8" id="7Ja64GBdw8K" role="1tU5fm">
+          <node concept="16syzq" id="7Ja64GBdw8L" role="A3Ik2">
+            <ref role="16sUi3" node="7Ja64GBdw8F" resolve="T1" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7Ja64GBdw8M" role="3clF46">
+        <property role="TrG5h" value="selector" />
+        <node concept="1ajhzC" id="7Ja64GBdw8N" role="1tU5fm">
+          <node concept="16syzq" id="7Ja64GBdw8O" role="1ajw0F">
+            <ref role="16sUi3" node="7Ja64GBdw8F" resolve="T1" />
+          </node>
+          <node concept="10Oyi0" id="7Ja64GBdw8P" role="1ajw0F" />
+          <node concept="3cqZAl" id="7Ja64GBdAln" role="1ajl9A" />
         </node>
       </node>
     </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/models/de.itemis.mps.baseLanguageExtensions.runtime.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/models/de.itemis.mps.baseLanguageExtensions.runtime.mps
@@ -21,6 +21,10 @@
       <concept id="1238853782547" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleLiteral" flags="nn" index="1Ls8ON">
         <child id="1238853845806" name="component" index="1Lso8e" />
       </concept>
+      <concept id="1238857743184" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleMemberAccessExpression" flags="nn" index="1LFfDK">
+        <child id="1238857764950" name="tuple" index="1LFl5Q" />
+        <child id="1238857834412" name="index" index="1LF_Uc" />
+      </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
@@ -29,6 +33,7 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1153422305557" name="jetbrains.mps.baseLanguage.structure.LessThanOrEqualsExpression" flags="nn" index="2dkUwp" />
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
@@ -151,6 +156,10 @@
       <concept id="1200830824066" name="jetbrains.mps.baseLanguage.closures.structure.YieldStatement" flags="nn" index="2n63Yl">
         <child id="1200830928149" name="expression" index="2n6tg2" />
       </concept>
+      <concept id="1235746970280" name="jetbrains.mps.baseLanguage.closures.structure.CompactInvokeFunctionExpression" flags="nn" index="2Sg_IR">
+        <child id="1235746996653" name="function" index="2SgG2M" />
+        <child id="1235747002942" name="parameter" index="2SgHGx" />
+      </concept>
       <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
         <child id="1199542457201" name="resultType" index="1ajl9A" />
         <child id="1199542501692" name="parameterType" index="1ajw0F" />
@@ -169,6 +178,9 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="1172650591544" name="jetbrains.mps.baseLanguage.collections.structure.SkipOperation" flags="nn" index="7r0gD">
         <child id="1172658456740" name="elementsToSkip" index="7T0AP" />
       </concept>
@@ -179,7 +191,9 @@
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
@@ -715,6 +729,99 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="54jQkZ8QoGf" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="7Ja64GBadPz">
+    <property role="TrG5h" value="SelectWithIndexOperationUtil" />
+    <node concept="2tJIrI" id="7Ja64GBah0u" role="jymVt" />
+    <node concept="2YIFZL" id="7Ja64GBadQG" role="jymVt">
+      <property role="TrG5h" value="selectWithIndex" />
+      <node concept="3clFbS" id="7Ja64GBadQJ" role="3clF47">
+        <node concept="3clFbF" id="7Ja64GBadZj" role="3cqZAp">
+          <node concept="2OqwBi" id="7Ja64GBaeQV" role="3clFbG">
+            <node concept="2YIFZM" id="7Ja64GBae0F" role="2Oq$k0">
+              <ref role="37wK5l" node="6vHuLLnJvrd" resolve="zip" />
+              <ref role="1Pybhc" node="6vHuLLnJvpc" resolve="ZipOperatorUtil" />
+              <node concept="37vLTw" id="7Ja64GBae4o" role="37wK5m">
+                <ref role="3cqZAo" node="7Ja64GBadT8" resolve="seq" />
+              </node>
+              <node concept="2YIFZM" id="7Ja64GBaejV" role="37wK5m">
+                <ref role="37wK5l" node="vJfcQmgyHy" resolve="range" />
+                <ref role="1Pybhc" node="vJfcQmguGr" resolve="IntegerSequence" />
+                <node concept="3cmrfG" id="7Ja64GBaeC0" role="37wK5m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+              </node>
+            </node>
+            <node concept="3$u5V9" id="7Ja64GBafdV" role="2OqNvi">
+              <node concept="1bVj0M" id="7Ja64GBafdX" role="23t8la">
+                <node concept="3clFbS" id="7Ja64GBafdY" role="1bW5cS">
+                  <node concept="3clFbF" id="7Ja64GBafnJ" role="3cqZAp">
+                    <node concept="2Sg_IR" id="7Ja64GBafIa" role="3clFbG">
+                      <node concept="37vLTw" id="7Ja64GBafIb" role="2SgG2M">
+                        <ref role="3cqZAo" node="7Ja64GBadU9" resolve="selector" />
+                      </node>
+                      <node concept="1LFfDK" id="7Ja64GBagcf" role="2SgHGx">
+                        <node concept="3cmrfG" id="7Ja64GBaglb" role="1LF_Uc">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="37vLTw" id="7Ja64GBafQw" role="1LFl5Q">
+                          <ref role="3cqZAo" node="7Ja64GBafdZ" resolve="it" />
+                        </node>
+                      </node>
+                      <node concept="1LFfDK" id="7Ja64GBagPG" role="2SgHGx">
+                        <node concept="3cmrfG" id="7Ja64GBagQ3" role="1LF_Uc">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="37vLTw" id="7Ja64GBagBg" role="1LFl5Q">
+                          <ref role="3cqZAo" node="7Ja64GBafdZ" resolve="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="7Ja64GBafdZ" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="7Ja64GBafe0" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7Ja64GBadQk" role="1B3o_S" />
+      <node concept="16euLQ" id="7Ja64GBadRc" role="16eVyc">
+        <property role="TrG5h" value="T1" />
+      </node>
+      <node concept="16euLQ" id="7Ja64GBadRA" role="16eVyc">
+        <property role="TrG5h" value="T2" />
+      </node>
+      <node concept="A3Dl8" id="7Ja64GBadSg" role="3clF45">
+        <node concept="16syzq" id="7Ja64GBadSF" role="A3Ik2">
+          <ref role="16sUi3" node="7Ja64GBadRA" resolve="T2" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7Ja64GBadT8" role="3clF46">
+        <property role="TrG5h" value="seq" />
+        <node concept="A3Dl8" id="7Ja64GBadT6" role="1tU5fm">
+          <node concept="16syzq" id="7Ja64GBadTG" role="A3Ik2">
+            <ref role="16sUi3" node="7Ja64GBadRc" resolve="T1" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7Ja64GBadU9" role="3clF46">
+        <property role="TrG5h" value="selector" />
+        <node concept="1ajhzC" id="7Ja64GBadUJ" role="1tU5fm">
+          <node concept="16syzq" id="7Ja64GBadVH" role="1ajw0F">
+            <ref role="16sUi3" node="7Ja64GBadRc" resolve="T1" />
+          </node>
+          <node concept="10Oyi0" id="7Ja64GBadWJ" role="1ajw0F" />
+          <node concept="16syzq" id="7Ja64GBadXi" role="1ajl9A">
+            <ref role="16sUi3" node="7Ja64GBadRA" resolve="T2" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="7Ja64GBadP$" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
@@ -22,6 +22,7 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1153422105332" name="jetbrains.mps.baseLanguage.structure.RemExpression" flags="nn" index="2dk9JS" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1224500799915" name="jetbrains.mps.baseLanguage.structure.BitwiseXorExpression" flags="nn" index="pVQyQ" />
@@ -68,6 +69,7 @@
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -130,8 +132,11 @@
       <concept id="571742531387697460" name="de.itemis.mps.baseLanguageExtensions.structure.IntegerRangeConstantBound" flags="ng" index="2hHTnT">
         <property id="7488777117046563852" name="value" index="KjLWg" />
       </concept>
+      <concept id="7915817776605258993" name="de.itemis.mps.baseLanguageExtensions.structure.SelectWithIndexOperation" flags="ng" index="2kBsqy" />
       <concept id="5842252078326680676" name="de.itemis.mps.baseLanguageExtensions.structure.GroupByOperation" flags="ng" index="2pSdkF" />
       <concept id="7488777117048605758" name="de.itemis.mps.baseLanguageExtensions.structure.ZipOperation" flags="ng" index="Kbfsy" />
+      <concept id="8919968723020343837" name="de.itemis.mps.baseLanguageExtensions.structure.ForEachWithIndexOperation" flags="ng" index="1sWJ9m" />
+      <concept id="8919968723020245069" name="de.itemis.mps.baseLanguageExtensions.structure.WhereWithIndexOperation" flags="ng" index="1sZn06" />
       <concept id="578371460444482140" name="de.itemis.mps.baseLanguageExtensions.structure.ElvisOperation" flags="ng" index="1w0Eer" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -156,6 +161,9 @@
       </concept>
       <concept id="1172664342967" name="jetbrains.mps.baseLanguage.collections.structure.TakeOperation" flags="nn" index="8ftyA">
         <child id="1172664372046" name="elementsToTake" index="8f$Dv" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
@@ -1164,6 +1172,210 @@
       <node concept="3cqZAl" id="54jQkZ8XzyV" role="3clF45" />
     </node>
     <node concept="3Tm1VV" id="54jQkZ8XvIV" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="7Ja64GBeFG6">
+    <property role="TrG5h" value="WithIndexOperationSandbox" />
+    <node concept="2YIFZL" id="7Ja64GBeGwu" role="jymVt">
+      <property role="TrG5h" value="usages" />
+      <node concept="3clFbS" id="7Ja64GBeGwx" role="3clF47">
+        <node concept="3cpWs8" id="7Ja64GBeOxe" role="3cqZAp">
+          <node concept="3cpWsn" id="7Ja64GBeOxf" role="3cpWs9">
+            <property role="TrG5h" value="numsAsStrings" />
+            <node concept="_YKpA" id="7Ja64GBeObs" role="1tU5fm">
+              <node concept="17QB3L" id="7Ja64GBeObv" role="_ZDj9" />
+            </node>
+            <node concept="2ShNRf" id="7Ja64GBeOxg" role="33vP2m">
+              <node concept="Tc6Ow" id="7Ja64GBeOxh" role="2ShVmc">
+                <node concept="17QB3L" id="7Ja64GBeOxi" role="HW$YZ" />
+                <node concept="Xl_RD" id="7Ja64GBeOxj" role="HW$Y0">
+                  <property role="Xl_RC" value="one" />
+                </node>
+                <node concept="Xl_RD" id="7Ja64GBeOxk" role="HW$Y0">
+                  <property role="Xl_RC" value="two" />
+                </node>
+                <node concept="Xl_RD" id="7Ja64GBeOxl" role="HW$Y0">
+                  <property role="Xl_RC" value="three" />
+                </node>
+                <node concept="Xl_RD" id="7Ja64GBeOxm" role="HW$Y0">
+                  <property role="Xl_RC" value="four" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7Ja64GBeVmZ" role="3cqZAp" />
+        <node concept="3cpWs8" id="7Ja64GBeUvm" role="3cqZAp">
+          <node concept="3cpWsn" id="7Ja64GBeUvn" role="3cpWs9">
+            <property role="TrG5h" value="indexAsPrefix" />
+            <node concept="A3Dl8" id="7Ja64GBeUts" role="1tU5fm">
+              <node concept="17QB3L" id="7Ja64GBeUtv" role="A3Ik2" />
+            </node>
+            <node concept="2OqwBi" id="7Ja64GBeUvo" role="33vP2m">
+              <property role="hSjvv" value="true" />
+              <node concept="37vLTw" id="7Ja64GBeUvp" role="2Oq$k0">
+                <ref role="3cqZAo" node="7Ja64GBeOxf" resolve="numsAsStrings" />
+              </node>
+              <node concept="2kBsqy" id="7Ja64GBeUvq" role="2OqNvi">
+                <node concept="1bVj0M" id="7Ja64GBeUvr" role="23t8la">
+                  <node concept="3clFbS" id="7Ja64GBeUvs" role="1bW5cS">
+                    <node concept="3clFbF" id="7Ja64GBeUvt" role="3cqZAp">
+                      <node concept="3cpWs3" id="7Ja64GBeUvu" role="3clFbG">
+                        <node concept="37vLTw" id="7Ja64GBeUvv" role="3uHU7w">
+                          <ref role="3cqZAo" node="7Ja64GBeUvz" resolve="it" />
+                        </node>
+                        <node concept="3cpWs3" id="7Ja64GBeUvw" role="3uHU7B">
+                          <node concept="37vLTw" id="7Ja64GBeUvx" role="3uHU7B">
+                            <ref role="3cqZAo" node="7Ja64GBeUv_" resolve="index" />
+                          </node>
+                          <node concept="Xl_RD" id="7Ja64GBeUvy" role="3uHU7w">
+                            <property role="Xl_RC" value=": " />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7Ja64GBeUvz" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7Ja64GBeUv$" role="1tU5fm" />
+                  </node>
+                  <node concept="37vLTG" id="7Ja64GBeUv_" role="1bW2Oz">
+                    <property role="TrG5h" value="index" />
+                    <node concept="10Oyi0" id="7Ja64GBeUvA" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7Ja64GBeUXK" role="3cqZAp">
+          <node concept="2OqwBi" id="7Ja64GBeUXH" role="3clFbG">
+            <node concept="10M0yZ" id="7Ja64GBeUXI" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" />
+            </node>
+            <node concept="liA8E" id="7Ja64GBeUXJ" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.Object)" resolve="println" />
+              <node concept="37vLTw" id="7Ja64GBeV7f" role="37wK5m">
+                <ref role="3cqZAo" node="7Ja64GBeUvn" resolve="indexAsPrefix" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7Ja64GBeViT" role="3cqZAp" />
+        <node concept="3cpWs8" id="7Ja64GBeNLz" role="3cqZAp">
+          <node concept="3cpWsn" id="7Ja64GBeNL$" role="3cpWs9">
+            <property role="TrG5h" value="onlyEvenIdx" />
+            <node concept="A3Dl8" id="7Ja64GBeNKi" role="1tU5fm">
+              <node concept="17QB3L" id="7Ja64GBeNKl" role="A3Ik2" />
+            </node>
+            <node concept="2OqwBi" id="7Ja64GBeNL_" role="33vP2m">
+              <property role="hSjvv" value="true" />
+              <node concept="37vLTw" id="7Ja64GBeOxn" role="2Oq$k0">
+                <ref role="3cqZAo" node="7Ja64GBeOxf" resolve="list" />
+              </node>
+              <node concept="1sZn06" id="7Ja64GBeNLH" role="2OqNvi">
+                <node concept="1bVj0M" id="7Ja64GBeNLI" role="23t8la">
+                  <node concept="3clFbS" id="7Ja64GBeNLJ" role="1bW5cS">
+                    <node concept="3clFbF" id="7Ja64GBeNLK" role="3cqZAp">
+                      <node concept="3clFbC" id="7Ja64GBeNLL" role="3clFbG">
+                        <node concept="3cmrfG" id="7Ja64GBeNLM" role="3uHU7w">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="2dk9JS" id="7Ja64GBeNLN" role="3uHU7B">
+                          <node concept="37vLTw" id="7Ja64GBeNLO" role="3uHU7B">
+                            <ref role="3cqZAo" node="7Ja64GBeNLS" resolve="index" />
+                          </node>
+                          <node concept="3cmrfG" id="7Ja64GBeNLP" role="3uHU7w">
+                            <property role="3cmrfH" value="2" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7Ja64GBeNLQ" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7Ja64GBeNLR" role="1tU5fm" />
+                  </node>
+                  <node concept="37vLTG" id="7Ja64GBeNLS" role="1bW2Oz">
+                    <property role="TrG5h" value="index" />
+                    <node concept="10Oyi0" id="7Ja64GBeNLT" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7Ja64GBeOec" role="3cqZAp">
+          <node concept="2OqwBi" id="7Ja64GBeOe9" role="3clFbG">
+            <node concept="10M0yZ" id="7Ja64GBeOea" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" />
+            </node>
+            <node concept="liA8E" id="7Ja64GBeOeb" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.Object)" resolve="println" />
+              <node concept="37vLTw" id="7Ja64GBeOfZ" role="37wK5m">
+                <ref role="3cqZAo" node="7Ja64GBeNL$" resolve="onlyEvenIdx" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7Ja64GBeVSZ" role="3cqZAp" />
+        <node concept="3clFbF" id="7Ja64GBeW1l" role="3cqZAp">
+          <node concept="2OqwBi" id="7Ja64GBeWIc" role="3clFbG">
+            <property role="hSjvv" value="true" />
+            <node concept="37vLTw" id="7Ja64GBeW1j" role="2Oq$k0">
+              <ref role="3cqZAo" node="7Ja64GBeOxf" resolve="numsAsStrings" />
+            </node>
+            <node concept="1sWJ9m" id="7Ja64GBeX3N" role="2OqNvi">
+              <node concept="1bVj0M" id="7Ja64GBeX3P" role="23t8la">
+                <node concept="3clFbS" id="7Ja64GBeX3Q" role="1bW5cS">
+                  <node concept="3clFbF" id="7Ja64GBeXa7" role="3cqZAp">
+                    <node concept="2OqwBi" id="7Ja64GBeXa4" role="3clFbG">
+                      <node concept="10M0yZ" id="7Ja64GBeXa5" role="2Oq$k0">
+                        <ref role="1PxDUh" to="wyt6:~System" />
+                        <ref role="3cqZAo" to="wyt6:~System.out" />
+                      </node>
+                      <node concept="liA8E" id="7Ja64GBeXa6" role="2OqNvi">
+                        <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                        <node concept="3cpWs3" id="7Ja64GBf365" role="37wK5m">
+                          <node concept="37vLTw" id="7Ja64GBf3DO" role="3uHU7w">
+                            <ref role="3cqZAo" node="7Ja64GBeX3R" resolve="it" />
+                          </node>
+                          <node concept="3cpWs3" id="7Ja64GBf2bC" role="3uHU7B">
+                            <node concept="3cpWs3" id="7Ja64GBeZBw" role="3uHU7B">
+                              <node concept="Xl_RD" id="7Ja64GBeXgD" role="3uHU7B">
+                                <property role="Xl_RC" value="index is " />
+                              </node>
+                              <node concept="37vLTw" id="7Ja64GBeZQa" role="3uHU7w">
+                                <ref role="3cqZAo" node="7Ja64GBeX3T" resolve="index" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="7Ja64GBf2pH" role="3uHU7w">
+                              <property role="Xl_RC" value=" and value is " />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="7Ja64GBeX3R" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="7Ja64GBeX3S" role="1tU5fm" />
+                </node>
+                <node concept="37vLTG" id="7Ja64GBeX3T" role="1bW2Oz">
+                  <property role="TrG5h" value="index" />
+                  <node concept="10Oyi0" id="7Ja64GBeX3V" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7Ja64GBeFHl" role="1B3o_S" />
+      <node concept="3cqZAl" id="7Ja64GBeFHy" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="7Ja64GBeFG7" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
@@ -511,8 +511,8 @@
                             <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
                           </node>
                         </node>
-                        <node concept="chp4Y" id="7Ja64GBawoq" role="3oSUPX">
-                          <ref role="cht4Q" to="pkab:6RqC_fThQjL" resolve="SelectWithIndexOperation" />
+                        <node concept="chp4Y" id="7Ja64GBe6dP" role="3oSUPX">
+                          <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
                         </node>
                       </node>
                       <node concept="3TrEf2" id="7Ja64GBar6k" role="2OqNvi">
@@ -539,6 +539,148 @@
               <node concept="1mIQ4w" id="7Ja64GBaqaz" role="2OqNvi">
                 <node concept="chp4Y" id="7Ja64GBaqa$" role="cj9EA">
                   <ref role="cht4Q" to="pkab:6RqC_fThQjL" resolve="SelectWithIndexOperation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="7Ja64GBe0Bj" role="3acgRq">
+      <ref role="30HIoZ" to="tpee:hqOqwz4" resolve="DotExpression" />
+      <node concept="gft3U" id="7Ja64GBe0Bk" role="1lVwrX">
+        <node concept="2YIFZM" id="7Ja64GBe17D" role="gfFT$">
+          <ref role="37wK5l" to="96gm:7Ja64GBdvMJ" resolve="whereWithIndex" />
+          <ref role="1Pybhc" to="96gm:7Ja64GBadPz" resolve="WithIndexOperationUtil" />
+          <node concept="10Nm6u" id="7Ja64GBe17E" role="37wK5m">
+            <node concept="29HgVG" id="7Ja64GBe17F" role="lGtFl">
+              <node concept="3NFfHV" id="7Ja64GBe17G" role="3NFExx">
+                <node concept="3clFbS" id="7Ja64GBe17H" role="2VODD2">
+                  <node concept="3clFbF" id="7Ja64GBe17I" role="3cqZAp">
+                    <node concept="2OqwBi" id="7Ja64GBe17J" role="3clFbG">
+                      <node concept="3TrEf2" id="7Ja64GBe17K" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+                      </node>
+                      <node concept="30H73N" id="7Ja64GBe17L" role="2Oq$k0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="10Nm6u" id="7Ja64GBe17M" role="37wK5m">
+            <node concept="1sPUBX" id="7Ja64GBe17N" role="lGtFl">
+              <ref role="v9R2y" node="54jQkZ9fKWX" resolve="switchClosureLiteral" />
+              <node concept="3NFfHV" id="7Ja64GBe17O" role="1sPUBK">
+                <node concept="3clFbS" id="7Ja64GBe17P" role="2VODD2">
+                  <node concept="3clFbF" id="7Ja64GBe17Q" role="3cqZAp">
+                    <node concept="2OqwBi" id="7Ja64GBe17R" role="3clFbG">
+                      <node concept="1PxgMI" id="7Ja64GBe17S" role="2Oq$k0">
+                        <node concept="2OqwBi" id="7Ja64GBe17T" role="1m5AlR">
+                          <node concept="30H73N" id="7Ja64GBe17U" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="7Ja64GBe17V" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                          </node>
+                        </node>
+                        <node concept="chp4Y" id="7Ja64GBe65N" role="3oSUPX">
+                          <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="7Ja64GBe17X" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="7Ja64GBe0BE" role="30HLyM">
+        <node concept="3clFbS" id="7Ja64GBe0BF" role="2VODD2">
+          <node concept="3clFbF" id="7Ja64GBe0BG" role="3cqZAp">
+            <node concept="2OqwBi" id="7Ja64GBe0BH" role="3clFbG">
+              <node concept="2OqwBi" id="7Ja64GBe0BI" role="2Oq$k0">
+                <node concept="30H73N" id="7Ja64GBe0BJ" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7Ja64GBe0BK" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="7Ja64GBe0BL" role="2OqNvi">
+                <node concept="chp4Y" id="7Ja64GBe10V" role="cj9EA">
+                  <ref role="cht4Q" to="pkab:7Ja64GBdQxd" resolve="WhereWithIndexOperation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="7Ja64GBeiOs" role="3acgRq">
+      <ref role="30HIoZ" to="tpee:hqOqwz4" resolve="DotExpression" />
+      <node concept="gft3U" id="7Ja64GBeiOt" role="1lVwrX">
+        <node concept="2YIFZM" id="7Ja64GBejPg" role="gfFT$">
+          <ref role="37wK5l" to="96gm:7Ja64GBdw8k" resolve="forEachWithIndex" />
+          <ref role="1Pybhc" to="96gm:7Ja64GBadPz" resolve="WithIndexOperationUtil" />
+          <node concept="10Nm6u" id="7Ja64GBejPh" role="37wK5m">
+            <node concept="29HgVG" id="7Ja64GBejPi" role="lGtFl">
+              <node concept="3NFfHV" id="7Ja64GBejPj" role="3NFExx">
+                <node concept="3clFbS" id="7Ja64GBejPk" role="2VODD2">
+                  <node concept="3clFbF" id="7Ja64GBejPl" role="3cqZAp">
+                    <node concept="2OqwBi" id="7Ja64GBejPm" role="3clFbG">
+                      <node concept="3TrEf2" id="7Ja64GBejPn" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+                      </node>
+                      <node concept="30H73N" id="7Ja64GBejPo" role="2Oq$k0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="10Nm6u" id="7Ja64GBejPp" role="37wK5m">
+            <node concept="1sPUBX" id="7Ja64GBejPq" role="lGtFl">
+              <ref role="v9R2y" node="54jQkZ9fKWX" resolve="switchClosureLiteral" />
+              <node concept="3NFfHV" id="7Ja64GBejPr" role="1sPUBK">
+                <node concept="3clFbS" id="7Ja64GBejPs" role="2VODD2">
+                  <node concept="3clFbF" id="7Ja64GBejPt" role="3cqZAp">
+                    <node concept="2OqwBi" id="7Ja64GBejPu" role="3clFbG">
+                      <node concept="1PxgMI" id="7Ja64GBejPv" role="2Oq$k0">
+                        <node concept="2OqwBi" id="7Ja64GBejPw" role="1m5AlR">
+                          <node concept="30H73N" id="7Ja64GBejPx" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="7Ja64GBejPy" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                          </node>
+                        </node>
+                        <node concept="chp4Y" id="7Ja64GBejPz" role="3oSUPX">
+                          <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="7Ja64GBejP$" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="7Ja64GBeiON" role="30HLyM">
+        <node concept="3clFbS" id="7Ja64GBeiOO" role="2VODD2">
+          <node concept="3clFbF" id="7Ja64GBeiOP" role="3cqZAp">
+            <node concept="2OqwBi" id="7Ja64GBeiOQ" role="3clFbG">
+              <node concept="2OqwBi" id="7Ja64GBeiOR" role="2Oq$k0">
+                <node concept="30H73N" id="7Ja64GBeiOS" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7Ja64GBeiOT" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="7Ja64GBeiOU" role="2OqNvi">
+                <node concept="chp4Y" id="7Ja64GBejEs" role="cj9EA">
+                  <ref role="cht4Q" to="pkab:7Ja64GBeeCt" resolve="ForEachWithIndexOperation" />
                 </node>
               </node>
             </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
@@ -34,7 +34,6 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
-      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -76,7 +75,6 @@
       </concept>
       <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ng" index="v9R3L">
         <reference id="1722980698497626483" name="template" index="v9R2y" />
-        <child id="1722980698497626405" name="actualArgument" index="v9R3O" />
       </concept>
       <concept id="1167168920554" name="jetbrains.mps.lang.generator.structure.BaseMappingRule_Condition" flags="in" index="30G5F_" />
       <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
@@ -91,18 +89,12 @@
       <concept id="1167327847730" name="jetbrains.mps.lang.generator.structure.Reduction_MappingRule" flags="lg" index="3aamgX">
         <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
       </concept>
-      <concept id="982871510064032177" name="jetbrains.mps.lang.generator.structure.IParameterizedTemplate" flags="ng" index="1s_3nv">
-        <child id="982871510064032342" name="parameter" index="1s_3oS" />
-      </concept>
       <concept id="982871510068000147" name="jetbrains.mps.lang.generator.structure.TemplateSwitchMacro" flags="lg" index="1sPUBX">
         <child id="982871510068000158" name="sourceNodeQuery" index="1sPUBK" />
       </concept>
       <concept id="1167756080639" name="jetbrains.mps.lang.generator.structure.PropertyMacro_GetPropertyValue" flags="in" index="3zFVjK" />
       <concept id="1167945743726" name="jetbrains.mps.lang.generator.structure.IfMacro_Condition" flags="in" index="3IZrLx" />
       <concept id="1167951910403" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodesQuery" flags="in" index="3JmXsc" />
-      <concept id="1805153994415891174" name="jetbrains.mps.lang.generator.structure.TemplateParameterDeclaration" flags="ng" index="1N15co">
-        <child id="1805153994415893199" name="type" index="1N15GL" />
-      </concept>
       <concept id="1168024337012" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodeQuery" flags="in" index="3NFfHV" />
       <concept id="1118773211870" name="jetbrains.mps.lang.generator.structure.IfMacro" flags="ln" index="1W57fq">
         <child id="1194989344771" name="alternativeConsequence" index="UU_$l" />
@@ -133,9 +125,6 @@
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
-        <reference id="1138405853777" name="concept" index="ehGHo" />
-      </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
@@ -159,12 +148,11 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
-      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
-      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
-      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
-        <child id="1225711182005" name="list" index="1y566C" />
-        <child id="1225711191269" name="index" index="1y58nS" />
+      <concept id="1172650591544" name="jetbrains.mps.baseLanguage.collections.structure.SkipOperation" flags="nn" index="7r0gD">
+        <child id="1172658456740" name="elementsToSkip" index="7T0AP" />
       </concept>
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="bUwia" id="7EVAkaCx$5S">
@@ -441,22 +429,6 @@
           <node concept="10Nm6u" id="54jQkZ9fKdF" role="37wK5m">
             <node concept="1sPUBX" id="54jQkZ9fKkf" role="lGtFl">
               <ref role="v9R2y" node="54jQkZ9fKWX" resolve="GroupByOperation" />
-              <node concept="2OqwBi" id="54jQkZ9fMYQ" role="v9R3O">
-                <node concept="1PxgMI" id="54jQkZ9fMFx" role="2Oq$k0">
-                  <node concept="chp4Y" id="54jQkZ9fMJ0" role="3oSUPX">
-                    <ref role="cht4Q" to="pkab:54jQkZ8WKL$" resolve="GroupByOperation" />
-                  </node>
-                  <node concept="2OqwBi" id="54jQkZ9fLlS" role="1m5AlR">
-                    <node concept="30H73N" id="54jQkZ9fL5F" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="54jQkZ9fLY9" role="2OqNvi">
-                      <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3TrEf2" id="54jQkZ9fNFp" role="2OqNvi">
-                  <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
-                </node>
-              </node>
               <node concept="3NFfHV" id="54jQkZ9ghak" role="1sPUBK">
                 <node concept="3clFbS" id="54jQkZ9ghal" role="2VODD2">
                   <node concept="3clFbF" id="54jQkZ9ghe5" role="3cqZAp">
@@ -503,50 +475,140 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="jVnub" id="54jQkZ9fKWX">
-    <property role="TrG5h" value="GroupByOperation" />
-    <node concept="1N15co" id="54jQkZ9fKWY" role="1s_3oS">
-      <property role="TrG5h" value="operation" />
-      <node concept="3Tqbb2" id="54jQkZ9fKXa" role="1N15GL">
-        <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+    <node concept="3aamgX" id="7Ja64GBaq9Y" role="3acgRq">
+      <ref role="30HIoZ" to="tpee:hqOqwz4" resolve="DotExpression" />
+      <node concept="gft3U" id="7Ja64GBaq9Z" role="1lVwrX">
+        <node concept="2YIFZM" id="7Ja64GBar5T" role="gfFT$">
+          <ref role="37wK5l" to="96gm:7Ja64GBadQG" resolve="selectWithIndex" />
+          <ref role="1Pybhc" to="96gm:7Ja64GBadPz" resolve="SelectWithIndexOperationUtil" />
+          <node concept="10Nm6u" id="7Ja64GBar5U" role="37wK5m">
+            <node concept="29HgVG" id="7Ja64GBar5V" role="lGtFl">
+              <node concept="3NFfHV" id="7Ja64GBar5W" role="3NFExx">
+                <node concept="3clFbS" id="7Ja64GBar5X" role="2VODD2">
+                  <node concept="3clFbF" id="7Ja64GBar5Y" role="3cqZAp">
+                    <node concept="2OqwBi" id="7Ja64GBar5Z" role="3clFbG">
+                      <node concept="3TrEf2" id="7Ja64GBar60" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+                      </node>
+                      <node concept="30H73N" id="7Ja64GBar61" role="2Oq$k0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="10Nm6u" id="7Ja64GBar62" role="37wK5m">
+            <node concept="1sPUBX" id="7Ja64GBar63" role="lGtFl">
+              <ref role="v9R2y" node="54jQkZ9fKWX" resolve="GroupByOperation" />
+              <node concept="3NFfHV" id="7Ja64GBar6b" role="1sPUBK">
+                <node concept="3clFbS" id="7Ja64GBar6c" role="2VODD2">
+                  <node concept="3clFbF" id="7Ja64GBar6d" role="3cqZAp">
+                    <node concept="2OqwBi" id="7Ja64GBar6e" role="3clFbG">
+                      <node concept="1PxgMI" id="7Ja64GBar6f" role="2Oq$k0">
+                        <node concept="2OqwBi" id="7Ja64GBar6h" role="1m5AlR">
+                          <node concept="30H73N" id="7Ja64GBar6i" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="7Ja64GBar6j" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                          </node>
+                        </node>
+                        <node concept="chp4Y" id="7Ja64GBawoq" role="3oSUPX">
+                          <ref role="cht4Q" to="pkab:6RqC_fThQjL" resolve="SelectWithIndexOperation" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="7Ja64GBar6k" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="7Ja64GBaqas" role="30HLyM">
+        <node concept="3clFbS" id="7Ja64GBaqat" role="2VODD2">
+          <node concept="3clFbF" id="7Ja64GBaqau" role="3cqZAp">
+            <node concept="2OqwBi" id="7Ja64GBaqav" role="3clFbG">
+              <node concept="2OqwBi" id="7Ja64GBaqaw" role="2Oq$k0">
+                <node concept="30H73N" id="7Ja64GBaqax" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7Ja64GBaqay" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="7Ja64GBaqaz" role="2OqNvi">
+                <node concept="chp4Y" id="7Ja64GBaqa$" role="cj9EA">
+                  <ref role="cht4Q" to="pkab:6RqC_fThQjL" resolve="SelectWithIndexOperation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
-    <node concept="3aamgX" id="54jQkZ9fNRG" role="3aUrZf">
+  </node>
+  <node concept="jVnub" id="54jQkZ9fKWX">
+    <property role="TrG5h" value="switchClosureLiteral" />
+    <node concept="3aamgX" id="7Ja64GBawMh" role="3aUrZf">
       <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
-      <node concept="gft3U" id="54jQkZ9g988" role="1lVwrX">
-        <node concept="1bVj0M" id="54jQkZ9grof" role="gfFT$">
-          <node concept="37vLTG" id="54jQkZ9groL" role="1bW2Oz">
+      <node concept="gft3U" id="7Ja64GBawMi" role="1lVwrX">
+        <node concept="1bVj0M" id="7Ja64GBawMj" role="gfFT$">
+          <node concept="3clFbS" id="7Ja64GBawMM" role="1bW5cS">
+            <node concept="3clFbF" id="7Ja64GBawMN" role="3cqZAp">
+              <node concept="10Nm6u" id="7Ja64GBawMO" role="3clFbG" />
+              <node concept="2b32R4" id="7Ja64GBawMP" role="lGtFl">
+                <node concept="3JmXsc" id="7Ja64GBawMQ" role="2P8S$">
+                  <node concept="3clFbS" id="7Ja64GBawMR" role="2VODD2">
+                    <node concept="3clFbF" id="7Ja64GBawMS" role="3cqZAp">
+                      <node concept="2OqwBi" id="7Ja64GBawMT" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GBawMU" role="2Oq$k0">
+                          <node concept="30H73N" id="7Ja64GBawMV" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="7Ja64GBawMW" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tp2c:htbW58J" resolve="body" />
+                          </node>
+                        </node>
+                        <node concept="3Tsc0h" id="7Ja64GBawMX" role="2OqNvi">
+                          <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTG" id="7Ja64GBaEws" role="1bW2Oz">
             <property role="TrG5h" value="it" />
-            <node concept="3uibUv" id="54jQkZ9grpo" role="1tU5fm">
+            <node concept="3uibUv" id="7Ja64GBaERI" role="1tU5fm">
               <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-              <node concept="29HgVG" id="54jQkZ9grrh" role="lGtFl">
-                <node concept="3NFfHV" id="54jQkZ9gAC7" role="3NFExx">
-                  <node concept="3clFbS" id="54jQkZ9gAC8" role="2VODD2">
-                    <node concept="3clFbF" id="54jQkZ9gAR4" role="3cqZAp">
-                      <node concept="2YIFZM" id="54jQkZ9gBYT" role="3clFbG">
+              <node concept="29HgVG" id="7Ja64GBaPH4" role="lGtFl">
+                <node concept="3NFfHV" id="7Ja64GBaPH5" role="3NFExx">
+                  <node concept="3clFbS" id="7Ja64GBaPH6" role="2VODD2">
+                    <node concept="3clFbF" id="7Ja64GBaPHc" role="3cqZAp">
+                      <node concept="2YIFZM" id="7Ja64GBaPYB" role="3clFbG">
                         <ref role="37wK5l" to="tp2g:hwak6Ex" resolve="copyTypeRecursively" />
                         <ref role="1Pybhc" to="tp2g:hv18zCR" resolve="ClassifierTypeUtil" />
-                        <node concept="2YIFZM" id="54jQkZ9gDaE" role="37wK5m">
+                        <node concept="2YIFZM" id="7Ja64GBaPYC" role="37wK5m">
                           <ref role="37wK5l" to="tp2g:hv18AMC" resolve="getTypeCoercedToClassifierType" />
                           <ref role="1Pybhc" to="tp2g:hv18zCR" resolve="ClassifierTypeUtil" />
-                          <node concept="2OqwBi" id="54jQkZ9hwee" role="37wK5m">
-                            <node concept="2OqwBi" id="54jQkZ9hkJ3" role="2Oq$k0">
-                              <node concept="1PxgMI" id="54jQkZ9h4c$" role="2Oq$k0">
-                                <node concept="chp4Y" id="54jQkZ9h4zP" role="3oSUPX">
-                                  <ref role="cht4Q" to="tp2c:U7sbC7HC1h" resolve="ClosureLiteralType" />
+                          <node concept="2OqwBi" id="7Ja64GBaPYD" role="37wK5m">
+                            <node concept="2OqwBi" id="7Ja64GBaUbQ" role="2Oq$k0">
+                              <node concept="1PxgMI" id="7Ja64GBaTw8" role="2Oq$k0">
+                                <property role="1BlNFB" value="true" />
+                                <node concept="chp4Y" id="7Ja64GBaTMx" role="3oSUPX">
+                                  <ref role="cht4Q" to="tp2c:htajhBZ" resolve="FunctionType" />
                                 </node>
-                                <node concept="2OqwBi" id="3612de$tQry" role="1m5AlR">
-                                  <node concept="30H73N" id="3612de$tQrz" role="2Oq$k0" />
-                                  <node concept="3JvlWi" id="3612de$tQr$" role="2OqNvi" />
+                                <node concept="2OqwBi" id="7Ja64GBaSQb" role="1m5AlR">
+                                  <node concept="30H73N" id="7Ja64GBaPYI" role="2Oq$k0" />
+                                  <node concept="3JvlWi" id="7Ja64GBaT4P" role="2OqNvi" />
                                 </node>
                               </node>
-                              <node concept="3Tsc0h" id="54jQkZ9hlm3" role="2OqNvi">
+                              <node concept="3Tsc0h" id="7Ja64GBaUOM" role="2OqNvi">
                                 <ref role="3TtcxE" to="tp2c:htajw4W" resolve="parameterType" />
                               </node>
                             </node>
-                            <node concept="1uHKPH" id="54jQkZ9hDFi" role="2OqNvi" />
+                            <node concept="1uHKPH" id="7Ja64GBaPYL" role="2OqNvi" />
                           </node>
                         </node>
                       </node>
@@ -555,30 +617,23 @@
                 </node>
               </node>
             </node>
-            <node concept="17Uvod" id="2oJmO5LUoUC" role="lGtFl">
+            <node concept="17Uvod" id="7Ja64GBaVbQ" role="lGtFl">
               <property role="2qtEX9" value="name" />
               <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
-              <node concept="3zFVjK" id="2oJmO5LUoUD" role="3zH0cK">
-                <node concept="3clFbS" id="2oJmO5LUoUE" role="2VODD2">
-                  <node concept="3clFbF" id="2oJmO5LUpuQ" role="3cqZAp">
-                    <node concept="2OqwBi" id="2oJmO5LUz$Q" role="3clFbG">
-                      <node concept="1PxgMI" id="2oJmO5LUz43" role="2Oq$k0">
-                        <node concept="chp4Y" id="2oJmO5LUz7f" role="3oSUPX">
-                          <ref role="cht4Q" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
-                        </node>
-                        <node concept="1y4W85" id="2oJmO5LUwtJ" role="1m5AlR">
-                          <node concept="3cmrfG" id="2oJmO5LUwz4" role="1y58nS">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="2OqwBi" id="2oJmO5LUpTD" role="1y566C">
-                            <node concept="30H73N" id="2oJmO5LUpuP" role="2Oq$k0" />
-                            <node concept="3Tsc0h" id="2oJmO5LUqoj" role="2OqNvi">
-                              <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
-                            </node>
+              <node concept="3zFVjK" id="7Ja64GBaVbR" role="3zH0cK">
+                <node concept="3clFbS" id="7Ja64GBaVbS" role="2VODD2">
+                  <node concept="3clFbF" id="7Ja64GBaV$V" role="3cqZAp">
+                    <node concept="2OqwBi" id="7Ja64GBb7Om" role="3clFbG">
+                      <node concept="2OqwBi" id="7Ja64GBb2lb" role="2Oq$k0">
+                        <node concept="2OqwBi" id="7Ja64GBaVWY" role="2Oq$k0">
+                          <node concept="30H73N" id="7Ja64GBaV$U" role="2Oq$k0" />
+                          <node concept="3Tsc0h" id="7Ja64GBaWiH" role="2OqNvi">
+                            <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
                           </node>
                         </node>
+                        <node concept="1uHKPH" id="7Ja64GBb6RO" role="2OqNvi" />
                       </node>
-                      <node concept="3TrcHB" id="2oJmO5LU_Wf" role="2OqNvi">
+                      <node concept="3TrcHB" id="7Ja64GBb8lc" role="2OqNvi">
                         <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                       </node>
                     </node>
@@ -587,22 +642,25 @@
               </node>
             </node>
           </node>
-          <node concept="3clFbS" id="54jQkZ9grog" role="1bW5cS">
-            <node concept="3clFbF" id="54jQkZ9grrZ" role="3cqZAp">
-              <node concept="10Nm6u" id="54jQkZ9grrY" role="3clFbG" />
-              <node concept="2b32R4" id="54jQkZ9grtV" role="lGtFl">
-                <node concept="3JmXsc" id="54jQkZ9grtW" role="2P8S$">
-                  <node concept="3clFbS" id="54jQkZ9grtX" role="2VODD2">
-                    <node concept="3clFbF" id="54jQkZ9grxP" role="3cqZAp">
-                      <node concept="2OqwBi" id="54jQkZ9gsEo" role="3clFbG">
-                        <node concept="2OqwBi" id="54jQkZ9grTO" role="2Oq$k0">
-                          <node concept="30H73N" id="54jQkZ9grxO" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="54jQkZ9gsl3" role="2OqNvi">
-                            <ref role="3Tt5mk" to="tp2c:htbW58J" resolve="body" />
-                          </node>
+          <node concept="37vLTG" id="7Ja64GBaE$D" role="1bW2Oz">
+            <property role="TrG5h" value="j" />
+            <node concept="3uibUv" id="7Ja64GBaF6w" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            </node>
+            <node concept="2b32R4" id="7Ja64GBaFat" role="lGtFl">
+              <node concept="3JmXsc" id="7Ja64GBaFaw" role="2P8S$">
+                <node concept="3clFbS" id="7Ja64GBaFax" role="2VODD2">
+                  <node concept="3clFbF" id="7Ja64GBaFaB" role="3cqZAp">
+                    <node concept="2OqwBi" id="7Ja64GBaL6C" role="3clFbG">
+                      <node concept="2OqwBi" id="7Ja64GBaFay" role="2Oq$k0">
+                        <node concept="3Tsc0h" id="7Ja64GBaFa_" role="2OqNvi">
+                          <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
                         </node>
-                        <node concept="3Tsc0h" id="54jQkZ9gtBb" role="2OqNvi">
-                          <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                        <node concept="30H73N" id="7Ja64GBaFaA" role="2Oq$k0" />
+                      </node>
+                      <node concept="7r0gD" id="7Ja64GBaPD_" role="2OqNvi">
+                        <node concept="3cmrfG" id="7Ja64GBaPDF" role="7T0AP">
+                          <property role="3cmrfH" value="1" />
                         </node>
                       </node>
                     </node>
@@ -613,40 +671,33 @@
           </node>
         </node>
       </node>
-      <node concept="30G5F_" id="54jQkZ9fNVy" role="30HLyM">
-        <node concept="3clFbS" id="54jQkZ9fNVz" role="2VODD2">
-          <node concept="3clFbF" id="54jQkZ9fO0o" role="3cqZAp">
-            <node concept="1Wc70l" id="54jQkZ9g42P" role="3clFbG">
-              <node concept="2OqwBi" id="54jQkZ9g5Rp" role="3uHU7w">
-                <node concept="1y4W85" id="54jQkZ9g5qE" role="2Oq$k0">
-                  <node concept="3cmrfG" id="54jQkZ9g5xw" role="1y58nS">
-                    <property role="3cmrfH" value="0" />
+      <node concept="30G5F_" id="7Ja64GBawMY" role="30HLyM">
+        <node concept="3clFbS" id="7Ja64GBawMZ" role="2VODD2">
+          <node concept="3clFbF" id="7Ja64GBawN0" role="3cqZAp">
+            <node concept="1Wc70l" id="7Ja64GBb8rp" role="3clFbG">
+              <node concept="2OqwBi" id="7Ja64GBbfle" role="3uHU7B">
+                <node concept="2OqwBi" id="7Ja64GBb8Eh" role="2Oq$k0">
+                  <node concept="30H73N" id="7Ja64GBb8_W" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="7Ja64GBb8Pu" role="2OqNvi">
+                    <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
                   </node>
-                  <node concept="2OqwBi" id="54jQkZ9g4oe" role="1y566C">
-                    <node concept="30H73N" id="54jQkZ9g45j" role="2Oq$k0" />
-                    <node concept="3Tsc0h" id="54jQkZ9g4vf" role="2OqNvi">
+                </node>
+                <node concept="3GX2aA" id="7Ja64GBbf$G" role="2OqNvi" />
+              </node>
+              <node concept="2OqwBi" id="7Ja64GBawN2" role="3uHU7w">
+                <node concept="2OqwBi" id="7Ja64GBbI8i" role="2Oq$k0">
+                  <node concept="2OqwBi" id="7Ja64GBawN5" role="2Oq$k0">
+                    <node concept="30H73N" id="7Ja64GBawN6" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="7Ja64GBawN7" role="2OqNvi">
                       <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
                     </node>
                   </node>
+                  <node concept="1uHKPH" id="7Ja64GBbMGl" role="2OqNvi" />
                 </node>
-                <node concept="1mIQ4w" id="54jQkZ9g6EK" role="2OqNvi">
-                  <node concept="chp4Y" id="54jQkZ9g8gt" role="cj9EA">
+                <node concept="1mIQ4w" id="7Ja64GBawN8" role="2OqNvi">
+                  <node concept="chp4Y" id="7Ja64GBawN9" role="cj9EA">
                     <ref role="cht4Q" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
                   </node>
-                </node>
-              </node>
-              <node concept="3clFbC" id="54jQkZ9g3lT" role="3uHU7B">
-                <node concept="2OqwBi" id="54jQkZ9fVmo" role="3uHU7B">
-                  <node concept="2OqwBi" id="54jQkZ9fOpL" role="2Oq$k0">
-                    <node concept="30H73N" id="54jQkZ9fO0n" role="2Oq$k0" />
-                    <node concept="3Tsc0h" id="54jQkZ9fOMq" role="2OqNvi">
-                      <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
-                    </node>
-                  </node>
-                  <node concept="34oBXx" id="54jQkZ9g1zZ" role="2OqNvi" />
-                </node>
-                <node concept="3cmrfG" id="54jQkZ9g3R_" role="3uHU7w">
-                  <property role="3cmrfH" value="1" />
                 </node>
               </node>
             </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.actions.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.actions.mps
@@ -31,6 +31,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -44,6 +45,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -56,6 +58,11 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
+        <child id="1196350785114" name="quotedNode" index="2c44tc" />
+      </concept>
     </language>
     <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
       <concept id="767145758118872833" name="jetbrains.mps.lang.actions.structure.NF_LinkList_AddNewChildOperation" flags="nn" index="2DeJg1" />
@@ -248,6 +255,204 @@
                         <property role="Xl_RC" value="it" />
                       </node>
                     </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="37WguZ" id="7Ja64GB9veW">
+    <property role="TrG5h" value="selectWithIndex_operation" />
+    <node concept="37WvkG" id="7Ja64GB9veX" role="37WGs$">
+      <ref role="37XkoT" to="pkab:6RqC_fThQjL" resolve="SelectWithIndexOperation" />
+      <node concept="37Y9Zx" id="7Ja64GB9veY" role="37ZfLb">
+        <node concept="3clFbS" id="7Ja64GB9veZ" role="2VODD2">
+          <node concept="3clFbJ" id="7Ja64GB9vgD" role="3cqZAp">
+            <node concept="2OqwBi" id="7Ja64GB9vpy" role="3clFbw">
+              <node concept="1r4N5L" id="7Ja64GB9vh2" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="7Ja64GB9vMH" role="2OqNvi">
+                <node concept="chp4Y" id="7Ja64GB9vOS" role="cj9EA">
+                  <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="7Ja64GB9vgF" role="3clFbx">
+              <node concept="3clFbF" id="7Ja64GB9vRp" role="3cqZAp">
+                <node concept="2OqwBi" id="7Ja64GB9wud" role="3clFbG">
+                  <node concept="2OqwBi" id="7Ja64GB9w3p" role="2Oq$k0">
+                    <node concept="1r4Lsj" id="7Ja64GB9vRo" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="7Ja64GB9whN" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                    </node>
+                  </node>
+                  <node concept="2oxUTD" id="7Ja64GB9wDC" role="2OqNvi">
+                    <node concept="2OqwBi" id="7Ja64GB9xDL" role="2oxUTC">
+                      <node concept="2OqwBi" id="7Ja64GB9xby" role="2Oq$k0">
+                        <node concept="1PxgMI" id="7Ja64GB9wUj" role="2Oq$k0">
+                          <node concept="chp4Y" id="7Ja64GB9wVv" role="3oSUPX">
+                            <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                          </node>
+                          <node concept="1r4N5L" id="7Ja64GB9wHc" role="1m5AlR" />
+                        </node>
+                        <node concept="3TrEf2" id="7Ja64GB9xrz" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                        </node>
+                      </node>
+                      <node concept="3YRAZt" id="7Ja64GB9xSD" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="9aQIb" id="7Ja64GB9xZ$" role="9aQIa">
+              <node concept="3clFbS" id="7Ja64GB9xZ_" role="9aQI4">
+                <node concept="3cpWs8" id="7Ja64GB9ytg" role="3cqZAp">
+                  <node concept="3cpWsn" id="7Ja64GB9yth" role="3cpWs9">
+                    <property role="TrG5h" value="sel" />
+                    <node concept="3Tqbb2" id="7Ja64GB9yqy" role="1tU5fm">
+                      <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+                    </node>
+                    <node concept="2OqwBi" id="7Ja64GB9yti" role="33vP2m">
+                      <node concept="1r4Lsj" id="7Ja64GB9ytj" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="7Ja64GB9ytk" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="7Ja64GB9yCV" role="3cqZAp">
+                  <node concept="3clFbS" id="7Ja64GB9yCX" role="3clFbx">
+                    <node concept="3clFbF" id="7Ja64GB9z0z" role="3cqZAp">
+                      <node concept="37vLTI" id="7Ja64GB9ziC" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GB9zKx" role="37vLTx">
+                          <node concept="2OqwBi" id="7Ja64GB9zvM" role="2Oq$k0">
+                            <node concept="1r4Lsj" id="7Ja64GB9zj8" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="7Ja64GB9zGL" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                            </node>
+                          </node>
+                          <node concept="2DeJnY" id="7Ja64GB9zW1" role="2OqNvi">
+                            <ref role="1A9B2P" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="7Ja64GB9z0x" role="37vLTJ">
+                          <ref role="3cqZAo" node="7Ja64GB9yth" resolve="sel" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="7Ja64GB9JEp" role="3cqZAp">
+                      <node concept="3cpWsn" id="7Ja64GB9JEq" role="3cpWs9">
+                        <property role="TrG5h" value="pDeclIt" />
+                        <node concept="3Tqbb2" id="7Ja64GB9JE8" role="1tU5fm">
+                          <ref role="ehGHo" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
+                        </node>
+                        <node concept="2OqwBi" id="7Ja64GB9JEr" role="33vP2m">
+                          <node concept="2OqwBi" id="7Ja64GB9JEs" role="2Oq$k0">
+                            <node concept="1PxgMI" id="7Ja64GB9JEt" role="2Oq$k0">
+                              <node concept="chp4Y" id="7Ja64GB9JEu" role="3oSUPX">
+                                <ref role="cht4Q" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                              </node>
+                              <node concept="37vLTw" id="7Ja64GB9JEv" role="1m5AlR">
+                                <ref role="3cqZAo" node="7Ja64GB9yth" resolve="sel" />
+                              </node>
+                            </node>
+                            <node concept="3Tsc0h" id="7Ja64GB9JEw" role="2OqNvi">
+                              <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                            </node>
+                          </node>
+                          <node concept="2DeJg1" id="7Ja64GB9JEx" role="2OqNvi">
+                            <ref role="1A0vxQ" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7Ja64GB9Nwa" role="3cqZAp">
+                      <node concept="2OqwBi" id="7Ja64GB9RLQ" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GB9NTc" role="2Oq$k0">
+                          <node concept="37vLTw" id="7Ja64GB9Nw8" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7Ja64GB9JEq" resolve="pDecl" />
+                          </node>
+                          <node concept="3TrcHB" id="7Ja64GB9Omk" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="tyxLq" id="7Ja64GB9S5z" role="2OqNvi">
+                          <node concept="Xl_RD" id="7Ja64GB9S63" role="tz02z">
+                            <property role="Xl_RC" value="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="7Ja64GB9UXN" role="3cqZAp">
+                      <node concept="3cpWsn" id="7Ja64GB9UXO" role="3cpWs9">
+                        <property role="TrG5h" value="pDeclIdx" />
+                        <node concept="3Tqbb2" id="7Ja64GB9UXy" role="1tU5fm">
+                          <ref role="ehGHo" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+                        </node>
+                        <node concept="2OqwBi" id="7Ja64GB9UXP" role="33vP2m">
+                          <node concept="2OqwBi" id="7Ja64GB9UXQ" role="2Oq$k0">
+                            <node concept="1PxgMI" id="7Ja64GB9UXR" role="2Oq$k0">
+                              <node concept="chp4Y" id="7Ja64GB9UXS" role="3oSUPX">
+                                <ref role="cht4Q" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                              </node>
+                              <node concept="37vLTw" id="7Ja64GB9UXT" role="1m5AlR">
+                                <ref role="3cqZAo" node="7Ja64GB9yth" resolve="sel" />
+                              </node>
+                            </node>
+                            <node concept="3Tsc0h" id="7Ja64GB9UXU" role="2OqNvi">
+                              <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                            </node>
+                          </node>
+                          <node concept="2DeJg1" id="7Ja64GB9UXV" role="2OqNvi">
+                            <ref role="1A0vxQ" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7Ja64GB9SaY" role="3cqZAp">
+                      <node concept="2OqwBi" id="7Ja64GB9ZZy" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GB9Z2L" role="2Oq$k0">
+                          <node concept="37vLTw" id="7Ja64GB9UXW" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7Ja64GB9UXO" resolve="pDeclIdx" />
+                          </node>
+                          <node concept="3TrcHB" id="7Ja64GB9Zt3" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="tyxLq" id="7Ja64GBa0jf" role="2OqNvi">
+                          <node concept="Xl_RD" id="7Ja64GBa0jJ" role="tz02z">
+                            <property role="Xl_RC" value="index" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7Ja64GBa0q5" role="3cqZAp">
+                      <node concept="2OqwBi" id="7Ja64GBa0IO" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GBa0uE" role="2Oq$k0">
+                          <node concept="37vLTw" id="7Ja64GBa0q3" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7Ja64GB9UXO" resolve="pDeclIdx" />
+                          </node>
+                          <node concept="3TrEf2" id="7Ja64GBa0vJ" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:4VkOLwjf83e" resolve="type" />
+                          </node>
+                        </node>
+                        <node concept="2oxUTD" id="7Ja64GBa0UL" role="2OqNvi">
+                          <node concept="2c44tf" id="7Ja64GBa0VS" role="2oxUTC">
+                            <node concept="10Oyi0" id="7Ja64GBa0Yx" role="2c44tc" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="7Ja64GB9S6W" role="3cqZAp" />
+                  </node>
+                  <node concept="2OqwBi" id="7Ja64GB9yPf" role="3clFbw">
+                    <node concept="37vLTw" id="7Ja64GB9yFX" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7Ja64GB9yth" resolve="sel" />
+                    </node>
+                    <node concept="3w_OXm" id="7Ja64GB9yW$" role="2OqNvi" />
                   </node>
                 </node>
               </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.actions.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.actions.mps
@@ -266,6 +266,7 @@
   </node>
   <node concept="37WguZ" id="7Ja64GB9veW">
     <property role="TrG5h" value="withIndex_operations" />
+    <property role="3GE5qa" value="withIndexOperations" />
     <node concept="37WvkG" id="7Ja64GB9veX" role="37WGs$">
       <ref role="37XkoT" to="pkab:6RqC_fThQjL" resolve="SelectWithIndexOperation" />
       <node concept="37Y9Zx" id="7Ja64GB9veY" role="37ZfLb">

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.actions.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.actions.mps
@@ -265,7 +265,7 @@
     </node>
   </node>
   <node concept="37WguZ" id="7Ja64GB9veW">
-    <property role="TrG5h" value="selectWithIndex_operation" />
+    <property role="TrG5h" value="withIndex_operations" />
     <node concept="37WvkG" id="7Ja64GB9veX" role="37WGs$">
       <ref role="37XkoT" to="pkab:6RqC_fThQjL" resolve="SelectWithIndexOperation" />
       <node concept="37Y9Zx" id="7Ja64GB9veY" role="37ZfLb">
@@ -453,6 +453,396 @@
                       <ref role="3cqZAo" node="7Ja64GB9yth" resolve="sel" />
                     </node>
                     <node concept="3w_OXm" id="7Ja64GB9yW$" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="37WvkG" id="7Ja64GBdSxq" role="37WGs$">
+      <ref role="37XkoT" to="pkab:7Ja64GBdQxd" resolve="WhereWithIndexOperation" />
+      <node concept="37Y9Zx" id="7Ja64GBdSxr" role="37ZfLb">
+        <node concept="3clFbS" id="7Ja64GBdSxs" role="2VODD2">
+          <node concept="3clFbJ" id="7Ja64GBdSyd" role="3cqZAp">
+            <node concept="2OqwBi" id="7Ja64GBdSye" role="3clFbw">
+              <node concept="1r4N5L" id="7Ja64GBdTJP" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="7Ja64GBdSyg" role="2OqNvi">
+                <node concept="chp4Y" id="7Ja64GBdSyh" role="cj9EA">
+                  <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="7Ja64GBdSyi" role="3clFbx">
+              <node concept="3clFbF" id="7Ja64GBdSyj" role="3cqZAp">
+                <node concept="2OqwBi" id="7Ja64GBdSyk" role="3clFbG">
+                  <node concept="2OqwBi" id="7Ja64GBdSyl" role="2Oq$k0">
+                    <node concept="1r4Lsj" id="7Ja64GBdSym" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="7Ja64GBdSyn" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                    </node>
+                  </node>
+                  <node concept="2oxUTD" id="7Ja64GBdSyo" role="2OqNvi">
+                    <node concept="2OqwBi" id="7Ja64GBdSyp" role="2oxUTC">
+                      <node concept="2OqwBi" id="7Ja64GBdSyq" role="2Oq$k0">
+                        <node concept="1PxgMI" id="7Ja64GBdSyr" role="2Oq$k0">
+                          <node concept="chp4Y" id="7Ja64GBdSys" role="3oSUPX">
+                            <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                          </node>
+                          <node concept="1r4N5L" id="7Ja64GBdSyt" role="1m5AlR" />
+                        </node>
+                        <node concept="3TrEf2" id="7Ja64GBdSyu" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                        </node>
+                      </node>
+                      <node concept="3YRAZt" id="7Ja64GBdSyv" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="9aQIb" id="7Ja64GBdSyw" role="9aQIa">
+              <node concept="3clFbS" id="7Ja64GBdSyx" role="9aQI4">
+                <node concept="3cpWs8" id="7Ja64GBdSyy" role="3cqZAp">
+                  <node concept="3cpWsn" id="7Ja64GBdSyz" role="3cpWs9">
+                    <property role="TrG5h" value="sel" />
+                    <node concept="3Tqbb2" id="7Ja64GBdSy$" role="1tU5fm">
+                      <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+                    </node>
+                    <node concept="2OqwBi" id="7Ja64GBdSy_" role="33vP2m">
+                      <node concept="1r4Lsj" id="7Ja64GBdSyA" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="7Ja64GBdSyB" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="7Ja64GBdSyC" role="3cqZAp">
+                  <node concept="3clFbS" id="7Ja64GBdSyD" role="3clFbx">
+                    <node concept="3clFbF" id="7Ja64GBdSyE" role="3cqZAp">
+                      <node concept="37vLTI" id="7Ja64GBdSyF" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GBdSyG" role="37vLTx">
+                          <node concept="2OqwBi" id="7Ja64GBdSyH" role="2Oq$k0">
+                            <node concept="1r4Lsj" id="7Ja64GBdSyI" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="7Ja64GBdSyJ" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                            </node>
+                          </node>
+                          <node concept="2DeJnY" id="7Ja64GBdSyK" role="2OqNvi">
+                            <ref role="1A9B2P" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="7Ja64GBdSyL" role="37vLTJ">
+                          <ref role="3cqZAo" node="7Ja64GBdSyz" resolve="sel" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="7Ja64GBdSyM" role="3cqZAp">
+                      <node concept="3cpWsn" id="7Ja64GBdSyN" role="3cpWs9">
+                        <property role="TrG5h" value="pDeclIt" />
+                        <node concept="3Tqbb2" id="7Ja64GBdSyO" role="1tU5fm">
+                          <ref role="ehGHo" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
+                        </node>
+                        <node concept="2OqwBi" id="7Ja64GBdSyP" role="33vP2m">
+                          <node concept="2OqwBi" id="7Ja64GBdSyQ" role="2Oq$k0">
+                            <node concept="1PxgMI" id="7Ja64GBdSyR" role="2Oq$k0">
+                              <node concept="chp4Y" id="7Ja64GBdSyS" role="3oSUPX">
+                                <ref role="cht4Q" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                              </node>
+                              <node concept="37vLTw" id="7Ja64GBdSyT" role="1m5AlR">
+                                <ref role="3cqZAo" node="7Ja64GBdSyz" resolve="sel" />
+                              </node>
+                            </node>
+                            <node concept="3Tsc0h" id="7Ja64GBdSyU" role="2OqNvi">
+                              <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                            </node>
+                          </node>
+                          <node concept="2DeJg1" id="7Ja64GBdSyV" role="2OqNvi">
+                            <ref role="1A0vxQ" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7Ja64GBdSyW" role="3cqZAp">
+                      <node concept="2OqwBi" id="7Ja64GBdSyX" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GBdSyY" role="2Oq$k0">
+                          <node concept="37vLTw" id="7Ja64GBdSyZ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7Ja64GBdSyN" resolve="pDeclIt" />
+                          </node>
+                          <node concept="3TrcHB" id="7Ja64GBdSz0" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="tyxLq" id="7Ja64GBdSz1" role="2OqNvi">
+                          <node concept="Xl_RD" id="7Ja64GBdSz2" role="tz02z">
+                            <property role="Xl_RC" value="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="7Ja64GBdSz3" role="3cqZAp">
+                      <node concept="3cpWsn" id="7Ja64GBdSz4" role="3cpWs9">
+                        <property role="TrG5h" value="pDeclIdx" />
+                        <node concept="3Tqbb2" id="7Ja64GBdSz5" role="1tU5fm">
+                          <ref role="ehGHo" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+                        </node>
+                        <node concept="2OqwBi" id="7Ja64GBdSz6" role="33vP2m">
+                          <node concept="2OqwBi" id="7Ja64GBdSz7" role="2Oq$k0">
+                            <node concept="1PxgMI" id="7Ja64GBdSz8" role="2Oq$k0">
+                              <node concept="chp4Y" id="7Ja64GBdSz9" role="3oSUPX">
+                                <ref role="cht4Q" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                              </node>
+                              <node concept="37vLTw" id="7Ja64GBdSza" role="1m5AlR">
+                                <ref role="3cqZAo" node="7Ja64GBdSyz" resolve="sel" />
+                              </node>
+                            </node>
+                            <node concept="3Tsc0h" id="7Ja64GBdSzb" role="2OqNvi">
+                              <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                            </node>
+                          </node>
+                          <node concept="2DeJg1" id="7Ja64GBdSzc" role="2OqNvi">
+                            <ref role="1A0vxQ" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7Ja64GBdSzd" role="3cqZAp">
+                      <node concept="2OqwBi" id="7Ja64GBdSze" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GBdSzf" role="2Oq$k0">
+                          <node concept="37vLTw" id="7Ja64GBdSzg" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7Ja64GBdSz4" resolve="pDeclIdx" />
+                          </node>
+                          <node concept="3TrcHB" id="7Ja64GBdSzh" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="tyxLq" id="7Ja64GBdSzi" role="2OqNvi">
+                          <node concept="Xl_RD" id="7Ja64GBdSzj" role="tz02z">
+                            <property role="Xl_RC" value="index" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7Ja64GBdSzk" role="3cqZAp">
+                      <node concept="2OqwBi" id="7Ja64GBdSzl" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GBdSzm" role="2Oq$k0">
+                          <node concept="37vLTw" id="7Ja64GBdSzn" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7Ja64GBdSz4" resolve="pDeclIdx" />
+                          </node>
+                          <node concept="3TrEf2" id="7Ja64GBdSzo" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:4VkOLwjf83e" resolve="type" />
+                          </node>
+                        </node>
+                        <node concept="2oxUTD" id="7Ja64GBdSzp" role="2OqNvi">
+                          <node concept="2c44tf" id="7Ja64GBdSzq" role="2oxUTC">
+                            <node concept="10Oyi0" id="7Ja64GBdSzr" role="2c44tc" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="7Ja64GBdSzs" role="3cqZAp" />
+                  </node>
+                  <node concept="2OqwBi" id="7Ja64GBdSzt" role="3clFbw">
+                    <node concept="37vLTw" id="7Ja64GBdSzu" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7Ja64GBdSyz" resolve="sel" />
+                    </node>
+                    <node concept="3w_OXm" id="7Ja64GBdSzv" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="37WvkG" id="7Ja64GBei$m" role="37WGs$">
+      <ref role="37XkoT" to="pkab:7Ja64GBeeCt" resolve="ForEachWithIndexOperation" />
+      <node concept="37Y9Zx" id="7Ja64GBei$n" role="37ZfLb">
+        <node concept="3clFbS" id="7Ja64GBei$o" role="2VODD2">
+          <node concept="3clFbJ" id="7Ja64GBei$p" role="3cqZAp">
+            <node concept="2OqwBi" id="7Ja64GBei$q" role="3clFbw">
+              <node concept="1r4N5L" id="7Ja64GBei$r" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="7Ja64GBei$s" role="2OqNvi">
+                <node concept="chp4Y" id="7Ja64GBei$t" role="cj9EA">
+                  <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="7Ja64GBei$u" role="3clFbx">
+              <node concept="3clFbF" id="7Ja64GBei$v" role="3cqZAp">
+                <node concept="2OqwBi" id="7Ja64GBei$w" role="3clFbG">
+                  <node concept="2OqwBi" id="7Ja64GBei$x" role="2Oq$k0">
+                    <node concept="1r4Lsj" id="7Ja64GBei$y" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="7Ja64GBei$z" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                    </node>
+                  </node>
+                  <node concept="2oxUTD" id="7Ja64GBei$$" role="2OqNvi">
+                    <node concept="2OqwBi" id="7Ja64GBei$_" role="2oxUTC">
+                      <node concept="2OqwBi" id="7Ja64GBei$A" role="2Oq$k0">
+                        <node concept="1PxgMI" id="7Ja64GBei$B" role="2Oq$k0">
+                          <node concept="chp4Y" id="7Ja64GBei$C" role="3oSUPX">
+                            <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                          </node>
+                          <node concept="1r4N5L" id="7Ja64GBei$D" role="1m5AlR" />
+                        </node>
+                        <node concept="3TrEf2" id="7Ja64GBei$E" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                        </node>
+                      </node>
+                      <node concept="3YRAZt" id="7Ja64GBei$F" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="9aQIb" id="7Ja64GBei$G" role="9aQIa">
+              <node concept="3clFbS" id="7Ja64GBei$H" role="9aQI4">
+                <node concept="3cpWs8" id="7Ja64GBei$I" role="3cqZAp">
+                  <node concept="3cpWsn" id="7Ja64GBei$J" role="3cpWs9">
+                    <property role="TrG5h" value="sel" />
+                    <node concept="3Tqbb2" id="7Ja64GBei$K" role="1tU5fm">
+                      <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+                    </node>
+                    <node concept="2OqwBi" id="7Ja64GBei$L" role="33vP2m">
+                      <node concept="1r4Lsj" id="7Ja64GBei$M" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="7Ja64GBei$N" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="7Ja64GBei$O" role="3cqZAp">
+                  <node concept="3clFbS" id="7Ja64GBei$P" role="3clFbx">
+                    <node concept="3clFbF" id="7Ja64GBei$Q" role="3cqZAp">
+                      <node concept="37vLTI" id="7Ja64GBei$R" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GBei$S" role="37vLTx">
+                          <node concept="2OqwBi" id="7Ja64GBei$T" role="2Oq$k0">
+                            <node concept="1r4Lsj" id="7Ja64GBei$U" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="7Ja64GBei$V" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                            </node>
+                          </node>
+                          <node concept="2DeJnY" id="7Ja64GBei$W" role="2OqNvi">
+                            <ref role="1A9B2P" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="7Ja64GBei$X" role="37vLTJ">
+                          <ref role="3cqZAo" node="7Ja64GBei$J" resolve="sel" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="7Ja64GBei$Y" role="3cqZAp">
+                      <node concept="3cpWsn" id="7Ja64GBei$Z" role="3cpWs9">
+                        <property role="TrG5h" value="pDeclIt" />
+                        <node concept="3Tqbb2" id="7Ja64GBei_0" role="1tU5fm">
+                          <ref role="ehGHo" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
+                        </node>
+                        <node concept="2OqwBi" id="7Ja64GBei_1" role="33vP2m">
+                          <node concept="2OqwBi" id="7Ja64GBei_2" role="2Oq$k0">
+                            <node concept="1PxgMI" id="7Ja64GBei_3" role="2Oq$k0">
+                              <node concept="chp4Y" id="7Ja64GBei_4" role="3oSUPX">
+                                <ref role="cht4Q" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                              </node>
+                              <node concept="37vLTw" id="7Ja64GBei_5" role="1m5AlR">
+                                <ref role="3cqZAo" node="7Ja64GBei$J" resolve="sel" />
+                              </node>
+                            </node>
+                            <node concept="3Tsc0h" id="7Ja64GBei_6" role="2OqNvi">
+                              <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                            </node>
+                          </node>
+                          <node concept="2DeJg1" id="7Ja64GBei_7" role="2OqNvi">
+                            <ref role="1A0vxQ" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7Ja64GBei_8" role="3cqZAp">
+                      <node concept="2OqwBi" id="7Ja64GBei_9" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GBei_a" role="2Oq$k0">
+                          <node concept="37vLTw" id="7Ja64GBei_b" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7Ja64GBei$Z" resolve="pDeclIt" />
+                          </node>
+                          <node concept="3TrcHB" id="7Ja64GBei_c" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="tyxLq" id="7Ja64GBei_d" role="2OqNvi">
+                          <node concept="Xl_RD" id="7Ja64GBei_e" role="tz02z">
+                            <property role="Xl_RC" value="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="7Ja64GBei_f" role="3cqZAp">
+                      <node concept="3cpWsn" id="7Ja64GBei_g" role="3cpWs9">
+                        <property role="TrG5h" value="pDeclIdx" />
+                        <node concept="3Tqbb2" id="7Ja64GBei_h" role="1tU5fm">
+                          <ref role="ehGHo" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+                        </node>
+                        <node concept="2OqwBi" id="7Ja64GBei_i" role="33vP2m">
+                          <node concept="2OqwBi" id="7Ja64GBei_j" role="2Oq$k0">
+                            <node concept="1PxgMI" id="7Ja64GBei_k" role="2Oq$k0">
+                              <node concept="chp4Y" id="7Ja64GBei_l" role="3oSUPX">
+                                <ref role="cht4Q" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                              </node>
+                              <node concept="37vLTw" id="7Ja64GBei_m" role="1m5AlR">
+                                <ref role="3cqZAo" node="7Ja64GBei$J" resolve="sel" />
+                              </node>
+                            </node>
+                            <node concept="3Tsc0h" id="7Ja64GBei_n" role="2OqNvi">
+                              <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                            </node>
+                          </node>
+                          <node concept="2DeJg1" id="7Ja64GBei_o" role="2OqNvi">
+                            <ref role="1A0vxQ" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7Ja64GBei_p" role="3cqZAp">
+                      <node concept="2OqwBi" id="7Ja64GBei_q" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GBei_r" role="2Oq$k0">
+                          <node concept="37vLTw" id="7Ja64GBei_s" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7Ja64GBei_g" resolve="pDeclIdx" />
+                          </node>
+                          <node concept="3TrcHB" id="7Ja64GBei_t" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="tyxLq" id="7Ja64GBei_u" role="2OqNvi">
+                          <node concept="Xl_RD" id="7Ja64GBei_v" role="tz02z">
+                            <property role="Xl_RC" value="index" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7Ja64GBei_w" role="3cqZAp">
+                      <node concept="2OqwBi" id="7Ja64GBei_x" role="3clFbG">
+                        <node concept="2OqwBi" id="7Ja64GBei_y" role="2Oq$k0">
+                          <node concept="37vLTw" id="7Ja64GBei_z" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7Ja64GBei_g" resolve="pDeclIdx" />
+                          </node>
+                          <node concept="3TrEf2" id="7Ja64GBei_$" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:4VkOLwjf83e" resolve="type" />
+                          </node>
+                        </node>
+                        <node concept="2oxUTD" id="7Ja64GBei__" role="2OqNvi">
+                          <node concept="2c44tf" id="7Ja64GBei_A" role="2oxUTC">
+                            <node concept="10Oyi0" id="7Ja64GBei_B" role="2c44tc" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="7Ja64GBei_C" role="3cqZAp" />
+                  </node>
+                  <node concept="2OqwBi" id="7Ja64GBei_D" role="3clFbw">
+                    <node concept="37vLTw" id="7Ja64GBei_E" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7Ja64GBei$J" resolve="sel" />
+                    </node>
+                    <node concept="3w_OXm" id="7Ja64GBei_F" role="2OqNvi" />
                   </node>
                 </node>
               </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
@@ -133,6 +133,23 @@
     <property role="TrG5h" value="SelectWithIndexOperation" />
     <property role="34LRSv" value="selectIdx" />
     <property role="R4oN_" value="transform each element and index" />
+    <property role="3GE5qa" value="withIndexOperations" />
+    <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+  </node>
+  <node concept="1TIwiD" id="7Ja64GBdQxd">
+    <property role="EcuMT" value="8919968723020245069" />
+    <property role="TrG5h" value="WhereWithIndexOperation" />
+    <property role="34LRSv" value="whereIdx" />
+    <property role="R4oN_" value="include only matched element" />
+    <property role="3GE5qa" value="withIndexOperations" />
+    <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+  </node>
+  <node concept="1TIwiD" id="7Ja64GBeeCt">
+    <property role="EcuMT" value="8919968723020343837" />
+    <property role="TrG5h" value="ForEachWithIndexOperation" />
+    <property role="34LRSv" value="forEachIdx" />
+    <property role="R4oN_" value="execute for each element with index" />
+    <property role="3GE5qa" value="withIndexOperations" />
     <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
   </node>
 </model>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
@@ -128,5 +128,12 @@
     <property role="3GE5qa" value="groupByOperation" />
     <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
   </node>
+  <node concept="1TIwiD" id="6RqC_fThQjL">
+    <property role="EcuMT" value="7915817776605258993" />
+    <property role="TrG5h" value="SelectWithIndexOperation" />
+    <property role="34LRSv" value="selectIdx" />
+    <property role="R4oN_" value="transform each element and index" />
+    <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+  </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
@@ -10,6 +10,7 @@
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
     <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
     <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" implicit="true" />
+    <import index="tpek" ref="r:00000000-0000-4000-0000-011c895902c0(jetbrains.mps.baseLanguage.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -63,6 +64,7 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -136,6 +138,7 @@
       </concept>
       <concept id="1174658326157" name="jetbrains.mps.lang.typesystem.structure.CreateEquationStatement" flags="nn" index="1Z5TYs" />
       <concept id="1174660718586" name="jetbrains.mps.lang.typesystem.structure.AbstractEquationStatement" flags="nn" index="1Zf1VF">
+        <property id="1206359757216" name="checkOnly" index="3wDh2S" />
         <child id="1174660783413" name="leftExpression" index="1ZfhK$" />
         <child id="1174660783414" name="rightExpression" index="1ZfhKB" />
       </concept>
@@ -150,6 +153,7 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
@@ -810,6 +814,7 @@
   </node>
   <node concept="1YbPZF" id="6RqC_fThRNY">
     <property role="TrG5h" value="typeof_SelectWithIndexOperation" />
+    <property role="3GE5qa" value="withIndexOperations" />
     <node concept="3clFbS" id="6RqC_fThRNZ" role="18ibNy">
       <node concept="1ZxtTE" id="6RqC_fThS0E" role="3cqZAp">
         <property role="TrG5h" value="seqParamType" />
@@ -889,6 +894,161 @@
     <node concept="1YaCAy" id="6RqC_fThRO1" role="1YuTPh">
       <property role="TrG5h" value="selectWithIndexOperation" />
       <ref role="1YaFvo" to="pkab:6RqC_fThQjL" resolve="SelectWithIndexOperation" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="7Ja64GBdQEI">
+    <property role="TrG5h" value="typeof_WhereWithIndexOperation" />
+    <property role="3GE5qa" value="withIndexOperations" />
+    <node concept="3clFbS" id="7Ja64GBdQEJ" role="18ibNy">
+      <node concept="1ZxtTE" id="hwyZbXq" role="3cqZAp">
+        <property role="TrG5h" value="paramType" />
+      </node>
+      <node concept="3clFbF" id="34jUqC_VPJv" role="3cqZAp">
+        <node concept="2YIFZM" id="34jUqC_VR5x" role="3clFbG">
+          <ref role="37wK5l" to="tp2v:4Iwp2tSBzXf" resolve="inferInternalOperation" />
+          <ref role="1Pybhc" to="tp2v:4Iwp2tSBvWa" resolve="OperationInference" />
+          <node concept="1YBJjd" id="34jUqC_VR5y" role="37wK5m">
+            <ref role="1YBMHb" node="7Ja64GBdQEL" resolve="wo" />
+          </node>
+          <node concept="1Z$b5t" id="34jUqC_VR5z" role="37wK5m">
+            <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
+          </node>
+          <node concept="2c44tf" id="7Ja64GBdQER" role="37wK5m">
+            <node concept="1ajhzC" id="7Ja64GBdQES" role="2c44tc">
+              <node concept="33vP2l" id="7Ja64GBdQET" role="1ajw0F">
+                <node concept="2c44te" id="7Ja64GBdQEU" role="lGtFl">
+                  <node concept="1Z$b5t" id="7Ja64GBdQEV" role="2c44t1">
+                    <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="10Oyi0" id="7Ja64GBdR9R" role="1ajw0F" />
+              <node concept="10P_77" id="34jUqC_VR5D" role="1ajl9A" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1Z5TYs" id="hwyZxSY" role="3cqZAp">
+        <node concept="mw_s8" id="hwyZRij" role="1ZfhKB">
+          <node concept="2c44tf" id="hwyZRik" role="mwGJk">
+            <node concept="A3Dl8" id="hwyZRB2" role="2c44tc">
+              <node concept="33vP2l" id="hwyZRB3" role="A3Ik2">
+                <node concept="2c44te" id="hwyZRRP" role="lGtFl">
+                  <node concept="1Z$b5t" id="hwyZS6_" role="2c44t1">
+                    <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hwyZxT1" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hwyZwPr" role="mwGJk">
+            <node concept="1YBJjd" id="hwyZxjd" role="1Z2MuG">
+              <ref role="1YBMHb" node="7Ja64GBdQEL" resolve="wo" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7Ja64GBdQEL" role="1YuTPh">
+      <property role="TrG5h" value="whereIdxOp" />
+      <ref role="1YaFvo" to="pkab:7Ja64GBdQxd" resolve="WhereWithIndexOperation" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="7Ja64GBegld">
+    <property role="TrG5h" value="typeof_ForEachWithIndexOperation" />
+    <property role="3GE5qa" value="withIndexOperations" />
+    <node concept="3clFbS" id="7Ja64GBegle" role="18ibNy">
+      <node concept="1ZxtTE" id="hPGn0$6" role="3cqZAp">
+        <property role="TrG5h" value="paramType" />
+      </node>
+      <node concept="nvevp" id="3qDC_E6ztIL" role="3cqZAp">
+        <node concept="3clFbS" id="3qDC_E6ztIN" role="nvhr_">
+          <node concept="1ZoDhX" id="6DFN5BsVqJf" role="3cqZAp">
+            <property role="3wDh2S" value="false" />
+            <node concept="mw_s8" id="3qDC_E6zv71" role="1ZfhKB">
+              <node concept="2X3wrD" id="3qDC_E6zv6V" role="mwGJk">
+                <ref role="2X3Bk0" node="3qDC_E6ztIR" resolve="O" />
+              </node>
+            </node>
+            <node concept="mw_s8" id="hPGtiwH" role="1ZfhK$">
+              <node concept="2c44tf" id="hPGtiwI" role="mwGJk">
+                <node concept="A3Dl8" id="hPGtiwJ" role="2c44tc">
+                  <node concept="33vP2l" id="hPGtiwK" role="A3Ik2">
+                    <node concept="2c44te" id="hPGtiwL" role="lGtFl">
+                      <node concept="1Z$b5t" id="hPGtiwM" role="2c44t1">
+                        <ref role="1Z$eMM" node="hPGn0$6" resolve="paramType" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1ZobV4" id="hPGmTCs" role="3cqZAp">
+            <node concept="mw_s8" id="hPGmUzT" role="1ZfhKB">
+              <node concept="2c44tf" id="hPGmUzU" role="mwGJk">
+                <node concept="1ajhzC" id="hPGmVdX" role="2c44tc">
+                  <node concept="33vP2l" id="hPGmVOy" role="1ajw0F">
+                    <node concept="2c44te" id="hPGn1GL" role="lGtFl">
+                      <node concept="1Z$b5t" id="hPGn1WU" role="2c44t1">
+                        <ref role="1Z$eMM" node="hPGn0$6" resolve="paramType" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="10Oyi0" id="7Ja64GBegVu" role="1ajw0F" />
+                  <node concept="3cqZAl" id="271UhN2N7Bs" role="1ajl9A" />
+                </node>
+              </node>
+            </node>
+            <node concept="mw_s8" id="hPGmTCw" role="1ZfhK$">
+              <node concept="1Z2H0r" id="hPGmR$c" role="mwGJk">
+                <node concept="2OqwBi" id="hPGmS7e" role="1Z2MuG">
+                  <node concept="1YBJjd" id="hPGmRZV" role="2Oq$k0">
+                    <ref role="1YBMHb" node="7Ja64GBeglg" resolve="vo" />
+                  </node>
+                  <node concept="3TrEf2" id="7Ja64GBegM7" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2X1qdy" id="3qDC_E6ztIR" role="2X0Ygz">
+          <property role="TrG5h" value="operandType" />
+          <node concept="2jxLKc" id="3qDC_E6ztIS" role="1tU5fm" />
+        </node>
+        <node concept="1Z2H0r" id="3qDC_E6zWkg" role="nvjzm">
+          <node concept="2OqwBi" id="3qDC_E6zu0P" role="1Z2MuG">
+            <node concept="1YBJjd" id="3qDC_E6ztQz" role="2Oq$k0">
+              <ref role="1YBMHb" node="7Ja64GBeglg" resolve="vo" />
+            </node>
+            <node concept="2qgKlT" id="3qDC_E6zuz8" role="2OqNvi">
+              <ref role="37wK5l" to="tpek:hEwIP$m" resolve="getOperand" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1Z5TYs" id="hz1N4AP" role="3cqZAp">
+        <node concept="mw_s8" id="hz1N55C" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hz1N55D" role="mwGJk">
+            <node concept="1YBJjd" id="hz1N5qN" role="1Z2MuG">
+              <ref role="1YBMHb" node="7Ja64GBeglg" resolve="vo" />
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hz1N6aE" role="1ZfhKB">
+          <node concept="2c44tf" id="hz1N6aF" role="mwGJk">
+            <node concept="3cqZAl" id="hz1N6vX" role="2c44tc" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7Ja64GBeglg" role="1YuTPh">
+      <property role="TrG5h" value="forEachIdxOp" />
+      <ref role="1YaFvo" to="pkab:7Ja64GBeeCt" resolve="ForEachWithIndexOperation" />
     </node>
   </node>
 </model>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
@@ -808,5 +808,88 @@
       <ref role="1YaFvo" to="pkab:54jQkZ8WKL$" resolve="GroupByOperation" />
     </node>
   </node>
+  <node concept="1YbPZF" id="6RqC_fThRNY">
+    <property role="TrG5h" value="typeof_SelectWithIndexOperation" />
+    <node concept="3clFbS" id="6RqC_fThRNZ" role="18ibNy">
+      <node concept="1ZxtTE" id="6RqC_fThS0E" role="3cqZAp">
+        <property role="TrG5h" value="seqParamType" />
+      </node>
+      <node concept="1ZxtTE" id="6RqC_fThS0F" role="3cqZAp">
+        <property role="TrG5h" value="returnType" />
+      </node>
+      <node concept="1ZxtTE" id="6RqC_fThT9o" role="3cqZAp">
+        <property role="TrG5h" value="selectorParamType" />
+      </node>
+      <node concept="1ZobV4" id="6RqC_fThTkm" role="3cqZAp">
+        <node concept="mw_s8" id="6RqC_fThTlB" role="1ZfhK$">
+          <node concept="1Z$b5t" id="6RqC_fThTl_" role="mwGJk">
+            <ref role="1Z$eMM" node="6RqC_fThS0E" resolve="paramType" />
+          </node>
+        </node>
+        <node concept="mw_s8" id="6RqC_fThTlK" role="1ZfhKB">
+          <node concept="1Z$b5t" id="6RqC_fThTlI" role="mwGJk">
+            <ref role="1Z$eMM" node="6RqC_fThT9o" resolve="selectorParamType" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="6RqC_fThS0G" role="3cqZAp">
+        <node concept="2YIFZM" id="6RqC_fThS0H" role="3clFbG">
+          <ref role="37wK5l" to="tp2v:4Iwp2tSBzXf" resolve="inferInternalOperation" />
+          <ref role="1Pybhc" to="tp2v:4Iwp2tSBvWa" resolve="OperationInference" />
+          <node concept="1YBJjd" id="6RqC_fThS0I" role="37wK5m">
+            <ref role="1YBMHb" node="6RqC_fThRO1" resolve="selectWithIndexOperation" />
+          </node>
+          <node concept="1Z$b5t" id="6RqC_fThS0J" role="37wK5m">
+            <ref role="1Z$eMM" node="6RqC_fThS0E" resolve="paramType" />
+          </node>
+          <node concept="2c44tf" id="6RqC_fThS0K" role="37wK5m">
+            <node concept="1ajhzC" id="6RqC_fThS0L" role="2c44tc">
+              <node concept="33vP2l" id="6RqC_fThS0M" role="1ajw0F">
+                <node concept="2c44te" id="6RqC_fThS0N" role="lGtFl">
+                  <node concept="1Z$b5t" id="6RqC_fThTqX" role="2c44t1">
+                    <ref role="1Z$eMM" node="6RqC_fThT9o" resolve="selectorParamType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="10Oyi0" id="6RqC_fThS8f" role="1ajw0F" />
+              <node concept="33vP2l" id="6RqC_fThS0P" role="1ajl9A">
+                <node concept="2c44te" id="6RqC_fThS0Q" role="lGtFl">
+                  <node concept="1Z$b5t" id="6RqC_fThS0R" role="2c44t1">
+                    <ref role="1Z$eMM" node="6RqC_fThS0F" resolve="keyType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1Z5TYs" id="6RqC_fThS0S" role="3cqZAp">
+        <node concept="mw_s8" id="6RqC_fThS0T" role="1ZfhKB">
+          <node concept="2c44tf" id="6RqC_fThS0U" role="mwGJk">
+            <node concept="A3Dl8" id="6RqC_fThSq7" role="2c44tc">
+              <node concept="10P_77" id="6RqC_fThSsx" role="A3Ik2">
+                <node concept="2c44te" id="6RqC_fThSsH" role="lGtFl">
+                  <node concept="1Z$b5t" id="6RqC_fThSsP" role="2c44t1">
+                    <ref role="1Z$eMM" node="6RqC_fThS0F" resolve="returnType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="6RqC_fThS13" role="1ZfhK$">
+          <node concept="1Z2H0r" id="6RqC_fThS14" role="mwGJk">
+            <node concept="1YBJjd" id="6RqC_fThSgE" role="1Z2MuG">
+              <ref role="1YBMHb" node="6RqC_fThRO1" resolve="selectWithIndexOperation" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6RqC_fThRO1" role="1YuTPh">
+      <property role="TrG5h" value="selectWithIndexOperation" />
+      <ref role="1YaFvo" to="pkab:6RqC_fThQjL" resolve="SelectWithIndexOperation" />
+    </node>
+  </node>
 </model>
 

--- a/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.withIndexOperation@tests.mps
+++ b/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.withIndexOperation@tests.mps
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:950cb589-b21d-4ed2-88f3-d465eda87ffe(de.itemis.mps.baseLanguageExtensions.test.withIndexOperation@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+  </languages>
+  <imports>
+    <import index="96gm" ref="r:2eaed950-3bc1-47cd-9b02-e917ff994d7c(de.itemis.mps.baseLanguageExtensions.runtime)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171931690126" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethod" flags="ig" index="3s$Bmu">
+        <property id="1171931690128" name="methodName" index="3s$Bm0" />
+      </concept>
+      <concept id="1171931851043" name="jetbrains.mps.baseLanguage.unitTest.structure.BTestCase" flags="ig" index="3s_ewN">
+        <property id="1171931851045" name="testCaseName" index="3s_ewP" />
+        <child id="1171931851044" name="testMethodList" index="3s_ewO" />
+      </concept>
+      <concept id="1171931858461" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethodList" flags="ng" index="3s_gsd">
+        <child id="1171931858462" name="testMethod" index="3s_gse" />
+      </concept>
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="6126991172893676625" name="jetbrains.mps.baseLanguage.collections.structure.ContainsAllOperation" flags="nn" index="BjQpj" />
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+    </language>
+  </registry>
+  <node concept="3s_ewN" id="7Ja64GBc5va">
+    <property role="3s_ewP" value="WithIndexOperation" />
+    <node concept="3Tm1VV" id="7Ja64GBc5vb" role="1B3o_S" />
+    <node concept="3s_gsd" id="7Ja64GBc5vc" role="3s_ewO">
+      <node concept="3s$Bmu" id="7Ja64GBc8AO" role="3s_gse">
+        <property role="3s$Bm0" value="selectWithIndex" />
+        <node concept="3cqZAl" id="7Ja64GBc8AP" role="3clF45" />
+        <node concept="3Tm1VV" id="7Ja64GBc8AQ" role="1B3o_S" />
+        <node concept="3clFbS" id="7Ja64GBc8AR" role="3clF47">
+          <node concept="3cpWs8" id="7Ja64GBcart" role="3cqZAp">
+            <node concept="3cpWsn" id="7Ja64GBcaru" role="3cpWs9">
+              <property role="TrG5h" value="nums" />
+              <node concept="_YKpA" id="7Ja64GBcaq4" role="1tU5fm">
+                <node concept="17QB3L" id="7Ja64GBcaq7" role="_ZDj9" />
+              </node>
+              <node concept="2ShNRf" id="7Ja64GBcarv" role="33vP2m">
+                <node concept="Tc6Ow" id="7Ja64GBcarw" role="2ShVmc">
+                  <node concept="17QB3L" id="7Ja64GBcarx" role="HW$YZ" />
+                  <node concept="Xl_RD" id="7Ja64GBcary" role="HW$Y0">
+                    <property role="Xl_RC" value="zero" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBcarz" role="HW$Y0">
+                    <property role="Xl_RC" value="one" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBcar$" role="HW$Y0">
+                    <property role="Xl_RC" value="two" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBcar_" role="HW$Y0">
+                    <property role="Xl_RC" value="three" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="7Ja64GBceGj" role="3cqZAp">
+            <node concept="3cpWsn" id="7Ja64GBceGk" role="3cpWs9">
+              <property role="TrG5h" value="expected" />
+              <node concept="_YKpA" id="7Ja64GBceGl" role="1tU5fm">
+                <node concept="17QB3L" id="7Ja64GBceGm" role="_ZDj9" />
+              </node>
+              <node concept="2ShNRf" id="7Ja64GBceGn" role="33vP2m">
+                <node concept="Tc6Ow" id="7Ja64GBceGo" role="2ShVmc">
+                  <node concept="17QB3L" id="7Ja64GBceGp" role="HW$YZ" />
+                  <node concept="Xl_RD" id="7Ja64GBceGq" role="HW$Y0">
+                    <property role="Xl_RC" value="0: zero" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBceGr" role="HW$Y0">
+                    <property role="Xl_RC" value="1: one" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBceGs" role="HW$Y0">
+                    <property role="Xl_RC" value="2: two" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBceGt" role="HW$Y0">
+                    <property role="Xl_RC" value="3: three" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="7Ja64GBcexr" role="3cqZAp">
+            <node concept="3cpWsn" id="7Ja64GBcexs" role="3cpWs9">
+              <property role="TrG5h" value="actual" />
+              <node concept="A3Dl8" id="7Ja64GBcely" role="1tU5fm">
+                <node concept="17QB3L" id="7Ja64GBcel_" role="A3Ik2" />
+              </node>
+              <node concept="2YIFZM" id="7Ja64GBcext" role="33vP2m">
+                <ref role="37wK5l" to="96gm:7Ja64GBadQG" resolve="selectWithIndex" />
+                <ref role="1Pybhc" to="96gm:7Ja64GBadPz" resolve="SelectWithIndexOperationUtil" />
+                <node concept="37vLTw" id="7Ja64GBcexu" role="37wK5m">
+                  <ref role="3cqZAo" node="7Ja64GBcaru" resolve="nums" />
+                </node>
+                <node concept="1bVj0M" id="7Ja64GBcexv" role="37wK5m">
+                  <node concept="3clFbS" id="7Ja64GBcexw" role="1bW5cS">
+                    <node concept="3clFbF" id="7Ja64GBcexx" role="3cqZAp">
+                      <node concept="3cpWs3" id="7Ja64GBcexy" role="3clFbG">
+                        <node concept="37vLTw" id="7Ja64GBcexz" role="3uHU7w">
+                          <ref role="3cqZAo" node="7Ja64GBcexB" resolve="it" />
+                        </node>
+                        <node concept="3cpWs3" id="7Ja64GBcex$" role="3uHU7B">
+                          <node concept="37vLTw" id="7Ja64GBcex_" role="3uHU7B">
+                            <ref role="3cqZAo" node="7Ja64GBcexD" resolve="i" />
+                          </node>
+                          <node concept="Xl_RD" id="7Ja64GBcexA" role="3uHU7w">
+                            <property role="Xl_RC" value=": " />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTG" id="7Ja64GBcexB" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="17QB3L" id="7Ja64GBcexC" role="1tU5fm" />
+                  </node>
+                  <node concept="37vLTG" id="7Ja64GBcexD" role="1bW2Oz">
+                    <property role="TrG5h" value="i" />
+                    <node concept="10Oyi0" id="7Ja64GBcexE" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3vwNmj" id="7Ja64GBcg6d" role="3cqZAp">
+            <node concept="17R0WA" id="7Ja64GBdpiA" role="3vwVQn">
+              <node concept="2OqwBi" id="7Ja64GBdqE2" role="3uHU7w">
+                <node concept="37vLTw" id="7Ja64GBdpTS" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7Ja64GBcexs" resolve="actual" />
+                </node>
+                <node concept="34oBXx" id="7Ja64GBdqU5" role="2OqNvi" />
+              </node>
+              <node concept="2OqwBi" id="7Ja64GBdmZT" role="3uHU7B">
+                <node concept="37vLTw" id="7Ja64GBdmpP" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7Ja64GBceGk" resolve="expected" />
+                </node>
+                <node concept="34oBXx" id="7Ja64GBdnAA" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3vwNmj" id="7Ja64GBdsVa" role="3cqZAp">
+            <node concept="2OqwBi" id="7Ja64GBcgAA" role="3vwVQn">
+              <node concept="37vLTw" id="7Ja64GBcg9U" role="2Oq$k0">
+                <ref role="3cqZAo" node="7Ja64GBceGk" resolve="expected" />
+              </node>
+              <node concept="BjQpj" id="7Ja64GBchzh" role="2OqNvi">
+                <node concept="37vLTw" id="7Ja64GBchCH" role="25WWJ7">
+                  <ref role="3cqZAo" node="7Ja64GBcexs" resolve="actual" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.withIndexOperation@tests.mps
+++ b/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.withIndexOperation@tests.mps
@@ -11,6 +11,12 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="nn" index="d57v9" />
+      <concept id="1153422105332" name="jetbrains.mps.baseLanguage.structure.RemExpression" flags="nn" index="2dk9JS" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -41,11 +47,15 @@
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
@@ -83,6 +93,11 @@
       <concept id="1171931858461" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethodList" flags="ng" index="3s_gsd">
         <child id="1171931858462" name="testMethod" index="3s_gse" />
       </concept>
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
       <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
         <child id="1171981057159" name="condition" index="3vwVQn" />
       </concept>
@@ -238,6 +253,207 @@
                   <ref role="3cqZAo" node="7Ja64GBcexs" resolve="actual" />
                 </node>
               </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="7Ja64GBetNJ" role="3s_gse">
+        <property role="3s$Bm0" value="whereWithIndex" />
+        <node concept="3cqZAl" id="7Ja64GBetNK" role="3clF45" />
+        <node concept="3Tm1VV" id="7Ja64GBetNL" role="1B3o_S" />
+        <node concept="3clFbS" id="7Ja64GBetNM" role="3clF47">
+          <node concept="3cpWs8" id="7Ja64GBetNN" role="3cqZAp">
+            <node concept="3cpWsn" id="7Ja64GBetNO" role="3cpWs9">
+              <property role="TrG5h" value="nums" />
+              <node concept="_YKpA" id="7Ja64GBetNP" role="1tU5fm">
+                <node concept="17QB3L" id="7Ja64GBetNQ" role="_ZDj9" />
+              </node>
+              <node concept="2ShNRf" id="7Ja64GBetNR" role="33vP2m">
+                <node concept="Tc6Ow" id="7Ja64GBetNS" role="2ShVmc">
+                  <node concept="17QB3L" id="7Ja64GBetNT" role="HW$YZ" />
+                  <node concept="Xl_RD" id="7Ja64GBetNU" role="HW$Y0">
+                    <property role="Xl_RC" value="zero" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBetNV" role="HW$Y0">
+                    <property role="Xl_RC" value="one" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBetNW" role="HW$Y0">
+                    <property role="Xl_RC" value="two" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBetNX" role="HW$Y0">
+                    <property role="Xl_RC" value="three" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="7Ja64GBeuvx" role="3cqZAp">
+            <node concept="3cpWsn" id="7Ja64GBeuvy" role="3cpWs9">
+              <property role="TrG5h" value="expected" />
+              <node concept="_YKpA" id="7Ja64GBeuvz" role="1tU5fm">
+                <node concept="17QB3L" id="7Ja64GBeuv$" role="_ZDj9" />
+              </node>
+              <node concept="2ShNRf" id="7Ja64GBeuv_" role="33vP2m">
+                <node concept="Tc6Ow" id="7Ja64GBeuvA" role="2ShVmc">
+                  <node concept="17QB3L" id="7Ja64GBeuvB" role="HW$YZ" />
+                  <node concept="Xl_RD" id="7Ja64GBeuvC" role="HW$Y0">
+                    <property role="Xl_RC" value="zero" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBeuvE" role="HW$Y0">
+                    <property role="Xl_RC" value="two" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="7Ja64GBetO9" role="3cqZAp">
+            <node concept="3cpWsn" id="7Ja64GBetOa" role="3cpWs9">
+              <property role="TrG5h" value="actual" />
+              <node concept="A3Dl8" id="7Ja64GBetOb" role="1tU5fm">
+                <node concept="17QB3L" id="7Ja64GBetOc" role="A3Ik2" />
+              </node>
+              <node concept="2YIFZM" id="7Ja64GBeuYb" role="33vP2m">
+                <ref role="37wK5l" to="96gm:7Ja64GBdvMJ" resolve="whereWithIndex" />
+                <ref role="1Pybhc" to="96gm:7Ja64GBadPz" resolve="WithIndexOperationUtil" />
+                <node concept="37vLTw" id="7Ja64GBeuYc" role="37wK5m">
+                  <ref role="3cqZAo" node="7Ja64GBetNO" resolve="nums" />
+                </node>
+                <node concept="1bVj0M" id="7Ja64GBeuYd" role="37wK5m">
+                  <node concept="3clFbS" id="7Ja64GBeuYe" role="1bW5cS">
+                    <node concept="3clFbF" id="7Ja64GBeuYf" role="3cqZAp">
+                      <node concept="3clFbC" id="7Ja64GBewDv" role="3clFbG">
+                        <node concept="3cmrfG" id="7Ja64GBewMN" role="3uHU7w">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="2dk9JS" id="7Ja64GBew$r" role="3uHU7B">
+                          <node concept="37vLTw" id="7Ja64GBevw$" role="3uHU7B">
+                            <ref role="3cqZAo" node="7Ja64GBeuYn" resolve="i" />
+                          </node>
+                          <node concept="3cmrfG" id="7Ja64GBew$A" role="3uHU7w">
+                            <property role="3cmrfH" value="2" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTG" id="7Ja64GBeuYl" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="17QB3L" id="7Ja64GBeuYm" role="1tU5fm" />
+                  </node>
+                  <node concept="37vLTG" id="7Ja64GBeuYn" role="1bW2Oz">
+                    <property role="TrG5h" value="i" />
+                    <node concept="10Oyi0" id="7Ja64GBeuYo" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3vwNmj" id="7Ja64GBetOr" role="3cqZAp">
+            <node concept="17R0WA" id="7Ja64GBetOs" role="3vwVQn">
+              <node concept="2OqwBi" id="7Ja64GBetOt" role="3uHU7w">
+                <node concept="37vLTw" id="7Ja64GBetOu" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7Ja64GBetOa" resolve="actual" />
+                </node>
+                <node concept="34oBXx" id="7Ja64GBetOv" role="2OqNvi" />
+              </node>
+              <node concept="2OqwBi" id="7Ja64GBetOw" role="3uHU7B">
+                <node concept="37vLTw" id="7Ja64GBetOx" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7Ja64GBeuvy" resolve="expected" />
+                </node>
+                <node concept="34oBXx" id="7Ja64GBetOy" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3vwNmj" id="7Ja64GBetOz" role="3cqZAp">
+            <node concept="2OqwBi" id="7Ja64GBetO$" role="3vwVQn">
+              <node concept="37vLTw" id="7Ja64GBetO_" role="2Oq$k0">
+                <ref role="3cqZAo" node="7Ja64GBeuvy" resolve="expected" />
+              </node>
+              <node concept="BjQpj" id="7Ja64GBetOA" role="2OqNvi">
+                <node concept="37vLTw" id="7Ja64GBetOB" role="25WWJ7">
+                  <ref role="3cqZAo" node="7Ja64GBetOa" resolve="actual" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="7Ja64GBey69" role="3s_gse">
+        <property role="3s$Bm0" value="forEachWithIndex" />
+        <node concept="3cqZAl" id="7Ja64GBey6a" role="3clF45" />
+        <node concept="3Tm1VV" id="7Ja64GBey6b" role="1B3o_S" />
+        <node concept="3clFbS" id="7Ja64GBey6c" role="3clF47">
+          <node concept="3cpWs8" id="7Ja64GBey6d" role="3cqZAp">
+            <node concept="3cpWsn" id="7Ja64GBey6e" role="3cpWs9">
+              <property role="TrG5h" value="nums" />
+              <node concept="_YKpA" id="7Ja64GBey6f" role="1tU5fm">
+                <node concept="17QB3L" id="7Ja64GBey6g" role="_ZDj9" />
+              </node>
+              <node concept="2ShNRf" id="7Ja64GBey6h" role="33vP2m">
+                <node concept="Tc6Ow" id="7Ja64GBey6i" role="2ShVmc">
+                  <node concept="17QB3L" id="7Ja64GBey6j" role="HW$YZ" />
+                  <node concept="Xl_RD" id="7Ja64GBey6k" role="HW$Y0">
+                    <property role="Xl_RC" value="zero" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBey6l" role="HW$Y0">
+                    <property role="Xl_RC" value="one" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBey6m" role="HW$Y0">
+                    <property role="Xl_RC" value="two" />
+                  </node>
+                  <node concept="Xl_RD" id="7Ja64GBey6n" role="HW$Y0">
+                    <property role="Xl_RC" value="three" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="7Ja64GBeyRq" role="3cqZAp">
+            <node concept="3cpWsn" id="7Ja64GBeyRt" role="3cpWs9">
+              <property role="TrG5h" value="accumulator" />
+              <node concept="10Oyi0" id="7Ja64GBeyRo" role="1tU5fm" />
+              <node concept="3cmrfG" id="7Ja64GBezvm" role="33vP2m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7Ja64GBeAfk" role="3cqZAp">
+            <node concept="2YIFZM" id="7Ja64GBez9R" role="3clFbG">
+              <ref role="37wK5l" to="96gm:7Ja64GBdw8k" resolve="forEachWithIndex" />
+              <ref role="1Pybhc" to="96gm:7Ja64GBadPz" resolve="WithIndexOperationUtil" />
+              <node concept="37vLTw" id="7Ja64GBez9S" role="37wK5m">
+                <ref role="3cqZAo" node="7Ja64GBey6e" resolve="nums" />
+              </node>
+              <node concept="1bVj0M" id="7Ja64GBez9T" role="37wK5m">
+                <node concept="3clFbS" id="7Ja64GBez9U" role="1bW5cS">
+                  <node concept="3clFbF" id="7Ja64GBez9V" role="3cqZAp">
+                    <node concept="d57v9" id="7Ja64GBe_Ht" role="3clFbG">
+                      <node concept="37vLTw" id="7Ja64GBe_MD" role="37vLTx">
+                        <ref role="3cqZAo" node="7Ja64GBeza3" resolve="i" />
+                      </node>
+                      <node concept="37vLTw" id="7Ja64GBezDT" role="37vLTJ">
+                        <ref role="3cqZAo" node="7Ja64GBeyRt" resolve="accumulator" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTG" id="7Ja64GBeza1" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="17QB3L" id="7Ja64GBeza2" role="1tU5fm" />
+                </node>
+                <node concept="37vLTG" id="7Ja64GBeza3" role="1bW2Oz">
+                  <property role="TrG5h" value="i" />
+                  <node concept="10Oyi0" id="7Ja64GBeza4" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="7Ja64GBeBn0" role="3cqZAp">
+            <node concept="37vLTw" id="7Ja64GBeBq_" role="3tpDZB">
+              <ref role="3cqZAo" node="7Ja64GBeyRt" resolve="accumulator" />
+            </node>
+            <node concept="3cmrfG" id="7Ja64GBeBtu" role="3tpDZA">
+              <property role="3cmrfH" value="6" />
             </node>
           </node>
         </node>


### PR DESCRIPTION
## Name
operations with index:
- `selectIdx({~it, int index => ...})`
- `whereIdx({~it, int index => ...})`
- `forEachIdx({~it, int index => ...})`

## Operation Type

Sequence operation

## Use Case

These operation allow to access the current index when applying the operation `select`, `where` or `forEach`.
These operations are lazy.

## Comments
