### PR TITLE
Add ScopeFunctionOperations to the new base language extensions

### DIFF
--- a/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/de.itemis.mps.baseLanguageExtensions.runtime.msd
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/de.itemis.mps.baseLanguageExtensions.runtime.msd
@@ -16,12 +16,15 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/models/de.itemis.mps.baseLanguageExtensions.runtime.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/models/de.itemis.mps.baseLanguageExtensions.runtime.mps
@@ -8,6 +8,7 @@
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />
+    <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="3" />
   </languages>
   <imports>
     <import index="urs3" ref="r:fc76aa36-3cff-41c7-b94b-eee0e8341932(jetbrains.mps.internal.collections.runtime)" />
@@ -156,6 +157,19 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
+    <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
+      <concept id="3693790620639876318" name="com.mbeddr.mpsutil.blutil.structure.BLDoc" flags="ng" index="2aEySx">
+        <child id="3693790620639876319" name="text" index="2aEySw" />
+      </concept>
+    </language>
+    <language id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext">
+      <concept id="2557074442922380897" name="de.slisson.mps.richtext.structure.Text" flags="ng" index="19SGf9">
+        <child id="2557074442922392302" name="words" index="19SJt6" />
+      </concept>
+      <concept id="2557074442922438156" name="de.slisson.mps.richtext.structure.Word" flags="ng" index="19SUe$">
+        <property id="2557074442922438158" name="escapedValue" index="19SUeA" />
+      </concept>
+    </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1200830824066" name="jetbrains.mps.baseLanguage.closures.structure.YieldStatement" flags="nn" index="2n63Yl">
         <child id="1200830928149" name="expression" index="2n6tg2" />
@@ -177,6 +191,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -465,29 +482,29 @@
                       <node concept="2n63Yl" id="6vHuLLnJzKH" role="3cqZAp">
                         <node concept="1Ls8ON" id="6vHuLLnJzOz" role="2n6tg2">
                           <node concept="2OqwBi" id="6vHuLLnJ$wI" role="1Lso8e">
+                            <node concept="1uHKPH" id="6vHuLLnJ$E3" role="2OqNvi" />
                             <node concept="37vLTw" id="6Q4_ev6vwEC" role="2Oq$k0">
                               <ref role="3cqZAo" node="6Q4_ev6vwE_" resolve="seq1" />
                             </node>
-                            <node concept="1uHKPH" id="6vHuLLnJ$E3" role="2OqNvi" />
                           </node>
                           <node concept="2OqwBi" id="6vHuLLnJ_56" role="1Lso8e">
+                            <node concept="1uHKPH" id="6vHuLLnJ_f8" role="2OqNvi" />
                             <node concept="37vLTw" id="6Q4_ev6vwXh" role="2Oq$k0">
                               <ref role="3cqZAo" node="6Q4_ev6vwXe" resolve="seq2" />
                             </node>
-                            <node concept="1uHKPH" id="6vHuLLnJ_f8" role="2OqNvi" />
                           </node>
                         </node>
                       </node>
                       <node concept="3clFbF" id="6vHuLLnJxGa" role="3cqZAp">
                         <node concept="37vLTI" id="6vHuLLnJyvD" role="3clFbG">
                           <node concept="2OqwBi" id="6vHuLLnJyEn" role="37vLTx">
-                            <node concept="37vLTw" id="6Q4_ev6vwED" role="2Oq$k0">
-                              <ref role="3cqZAo" node="6Q4_ev6vwE_" resolve="seq1" />
-                            </node>
                             <node concept="7r0gD" id="6vHuLLnJyOe" role="2OqNvi">
                               <node concept="3cmrfG" id="6vHuLLnJyTj" role="7T0AP">
                                 <property role="3cmrfH" value="1" />
                               </node>
+                            </node>
+                            <node concept="37vLTw" id="6Q4_ev6vwED" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6Q4_ev6vwE_" resolve="seq1" />
                             </node>
                           </node>
                           <node concept="37vLTw" id="6Q4_ev6vwEE" role="37vLTJ">
@@ -498,13 +515,13 @@
                       <node concept="3clFbF" id="6vHuLLnJz2l" role="3cqZAp">
                         <node concept="37vLTI" id="6vHuLLnJzg2" role="3clFbG">
                           <node concept="2OqwBi" id="6vHuLLnJzph" role="37vLTx">
-                            <node concept="37vLTw" id="6Q4_ev6vwXi" role="2Oq$k0">
-                              <ref role="3cqZAo" node="6Q4_ev6vwXe" resolve="seq2" />
-                            </node>
                             <node concept="7r0gD" id="6vHuLLnJzz8" role="2OqNvi">
                               <node concept="3cmrfG" id="6vHuLLnJzCd" role="7T0AP">
                                 <property role="3cmrfH" value="1" />
                               </node>
+                            </node>
+                            <node concept="37vLTw" id="6Q4_ev6vwXi" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6Q4_ev6vwXe" resolve="seq2" />
                             </node>
                           </node>
                           <node concept="37vLTw" id="6Q4_ev6vwXj" role="37vLTJ">
@@ -515,16 +532,16 @@
                     </node>
                     <node concept="1Wc70l" id="6vHuLLnJx3h" role="2$JKZa">
                       <node concept="2OqwBi" id="6vHuLLnJM1h" role="3uHU7w">
+                        <node concept="3GX2aA" id="6vHuLLnJxAZ" role="2OqNvi" />
                         <node concept="37vLTw" id="6Q4_ev6vwXg" role="2Oq$k0">
                           <ref role="3cqZAo" node="6Q4_ev6vwXe" resolve="seq2" />
                         </node>
-                        <node concept="3GX2aA" id="6vHuLLnJxAZ" role="2OqNvi" />
                       </node>
                       <node concept="2OqwBi" id="6vHuLLnJLV6" role="3uHU7B">
+                        <node concept="3GX2aA" id="6vHuLLnJwot" role="2OqNvi" />
                         <node concept="37vLTw" id="6Q4_ev6vwEB" role="2Oq$k0">
                           <ref role="3cqZAo" node="6Q4_ev6vwE_" resolve="seq1" />
                         </node>
-                        <node concept="3GX2aA" id="6vHuLLnJwot" role="2OqNvi" />
                       </node>
                     </node>
                   </node>
@@ -578,12 +595,6 @@
         <node concept="3cpWs8" id="54jQkZ8R36P" role="3cqZAp">
           <node concept="3cpWsn" id="54jQkZ8R36Q" role="3cpWs9">
             <property role="TrG5h" value="cache" />
-            <node concept="2ShNRf" id="54jQkZ8R56d" role="33vP2m">
-              <node concept="1pGfFk" id="54jQkZ8R6Ug" role="2ShVmc">
-                <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="33ny:~HashMap.&lt;init&gt;()" resolve="HashMap" />
-              </node>
-            </node>
             <node concept="3uibUv" id="54jQkZ8R36N" role="1tU5fm">
               <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
               <node concept="16syzq" id="54jQkZ8R3wI" role="11_B2D">
@@ -594,6 +605,12 @@
                 <node concept="16syzq" id="54jQkZ8R4qE" role="11_B2D">
                   <ref role="16sUi3" node="54jQkZ8QoI8" resolve="T" />
                 </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="54jQkZ8R56d" role="33vP2m">
+              <node concept="1pGfFk" id="54jQkZ8R6Ug" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="33ny:~HashMap.&lt;init&gt;()" resolve="HashMap" />
               </node>
             </node>
           </node>
@@ -721,6 +738,18 @@
         </node>
       </node>
       <node concept="3Tm1VV" id="54jQkZ8QoH9" role="1B3o_S" />
+      <node concept="3uibUv" id="54jQkZ8QQ0a" role="3clF45">
+        <ref role="3uigEE" to="urs3:5Ffu4tBU$6H" resolve="IMapSequence" />
+        <node concept="16syzq" id="54jQkZ8QQ11" role="11_B2D">
+          <ref role="16sUi3" node="54jQkZ8QpwM" resolve="K" />
+        </node>
+        <node concept="3uibUv" id="54jQkZ8QQ1W" role="11_B2D">
+          <ref role="3uigEE" to="urs3:5Ffu4tBUx5R" resolve="ISequence" />
+          <node concept="16syzq" id="54jQkZ8QQ3y" role="11_B2D">
+            <ref role="16sUi3" node="54jQkZ8QoI8" resolve="T" />
+          </node>
+        </node>
+      </node>
       <node concept="16euLQ" id="54jQkZ8QoI8" role="16eVyc">
         <property role="TrG5h" value="T" />
       </node>
@@ -743,18 +772,6 @@
             <ref role="16sUi3" node="54jQkZ8QpwM" resolve="K" />
           </node>
           <node concept="16syzq" id="54jQkZ8Qpwm" role="1ajw0F">
-            <ref role="16sUi3" node="54jQkZ8QoI8" resolve="T" />
-          </node>
-        </node>
-      </node>
-      <node concept="3uibUv" id="54jQkZ8QQ0a" role="3clF45">
-        <ref role="3uigEE" to="urs3:5Ffu4tBU$6H" resolve="IMapSequence" />
-        <node concept="16syzq" id="54jQkZ8QQ11" role="11_B2D">
-          <ref role="16sUi3" node="54jQkZ8QpwM" resolve="K" />
-        </node>
-        <node concept="3uibUv" id="54jQkZ8QQ1W" role="11_B2D">
-          <ref role="3uigEE" to="urs3:5Ffu4tBUx5R" resolve="ISequence" />
-          <node concept="16syzq" id="54jQkZ8QQ3y" role="11_B2D">
             <ref role="16sUi3" node="54jQkZ8QoI8" resolve="T" />
           </node>
         </node>
@@ -1062,6 +1079,191 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="7Ja64GBadP$" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="2oJmO5LUej2">
+    <property role="TrG5h" value="ScopeFunctionUtil" />
+    <node concept="2YIFZL" id="2oJmO5LUek_" role="jymVt">
+      <property role="TrG5h" value="apply" />
+      <node concept="3clFbS" id="2oJmO5LUekC" role="3clF47">
+        <node concept="3clFbF" id="2oJmO5LUeru" role="3cqZAp">
+          <node concept="2OqwBi" id="2oJmO5LUesR" role="3clFbG">
+            <node concept="37vLTw" id="2oJmO5LUert" role="2Oq$k0">
+              <ref role="3cqZAo" node="2oJmO5LUemc" resolve="function" />
+            </node>
+            <node concept="1Bd96e" id="2oJmO5LUeCF" role="2OqNvi">
+              <node concept="37vLTw" id="2oJmO5LUeEu" role="1BdPVh">
+                <ref role="3cqZAo" node="2oJmO5LUema" resolve="callee" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="2oJmO5LUeHP" role="3cqZAp">
+          <node concept="37vLTw" id="2oJmO5LUeLy" role="3cqZAk">
+            <ref role="3cqZAo" node="2oJmO5LUema" resolve="callee" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2oJmO5LUek5" role="1B3o_S" />
+      <node concept="16syzq" id="2oJmO5LUelI" role="3clF45">
+        <ref role="16sUi3" node="2oJmO5LUel4" resolve="T" />
+      </node>
+      <node concept="16euLQ" id="2oJmO5LUel4" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+      <node concept="16euLQ" id="2oJmO5LWdCA" role="16eVyc">
+        <property role="TrG5h" value="R" />
+      </node>
+      <node concept="37vLTG" id="2oJmO5LUema" role="3clF46">
+        <property role="TrG5h" value="callee" />
+        <node concept="16syzq" id="2oJmO5LUem9" role="1tU5fm">
+          <ref role="16sUi3" node="2oJmO5LUel4" resolve="T" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2oJmO5LUemc" role="3clF46">
+        <property role="TrG5h" value="function" />
+        <node concept="1ajhzC" id="2oJmO5LUemG" role="1tU5fm">
+          <node concept="16syzq" id="2oJmO5LWdDt" role="1ajl9A">
+            <ref role="16sUi3" node="2oJmO5LWdCA" resolve="R" />
+          </node>
+          <node concept="16syzq" id="2oJmO5LUen8" role="1ajw0F">
+            <ref role="16sUi3" node="2oJmO5LUel4" resolve="T" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2YIFZL" id="2oJmO5LXrKn" role="jymVt">
+      <property role="TrG5h" value="applyVoid" />
+      <node concept="3clFbS" id="2oJmO5LXrKo" role="3clF47">
+        <node concept="3clFbF" id="2oJmO5LXrKp" role="3cqZAp">
+          <node concept="2OqwBi" id="2oJmO5LXrKq" role="3clFbG">
+            <node concept="37vLTw" id="2oJmO5LXrKr" role="2Oq$k0">
+              <ref role="3cqZAo" node="2oJmO5LXrKA" resolve="function" />
+            </node>
+            <node concept="1Bd96e" id="2oJmO5LXrKs" role="2OqNvi">
+              <node concept="37vLTw" id="2oJmO5LXrKt" role="1BdPVh">
+                <ref role="3cqZAo" node="2oJmO5LXrK$" resolve="callee" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="2oJmO5LXrKu" role="3cqZAp">
+          <node concept="37vLTw" id="2oJmO5LXrKv" role="3cqZAk">
+            <ref role="3cqZAo" node="2oJmO5LXrK$" resolve="callee" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2oJmO5LXrKw" role="1B3o_S" />
+      <node concept="16syzq" id="2oJmO5LXrKx" role="3clF45">
+        <ref role="16sUi3" node="2oJmO5LXrKy" resolve="T" />
+      </node>
+      <node concept="16euLQ" id="2oJmO5LXrKy" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+      <node concept="37vLTG" id="2oJmO5LXrK$" role="3clF46">
+        <property role="TrG5h" value="callee" />
+        <node concept="16syzq" id="2oJmO5LXrK_" role="1tU5fm">
+          <ref role="16sUi3" node="2oJmO5LXrKy" resolve="T" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2oJmO5LXrKA" role="3clF46">
+        <property role="TrG5h" value="function" />
+        <node concept="1ajhzC" id="2oJmO5LXrKB" role="1tU5fm">
+          <node concept="3cqZAl" id="2oJmO5LXrQ2" role="1ajl9A" />
+          <node concept="16syzq" id="2oJmO5LXrKD" role="1ajw0F">
+            <ref role="16sUi3" node="2oJmO5LXrKy" resolve="T" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2YIFZL" id="2oJmO5LUeQ4" role="jymVt">
+      <property role="TrG5h" value="let" />
+      <node concept="3clFbS" id="2oJmO5LUeQ7" role="3clF47">
+        <node concept="3clFbF" id="2oJmO5LUeWM" role="3cqZAp">
+          <node concept="2OqwBi" id="2oJmO5LUeYf" role="3clFbG">
+            <node concept="37vLTw" id="2oJmO5LUeWL" role="2Oq$k0">
+              <ref role="3cqZAo" node="2oJmO5LUeTm" resolve="function" />
+            </node>
+            <node concept="1Bd96e" id="2oJmO5LUff$" role="2OqNvi">
+              <node concept="37vLTw" id="2oJmO5LUfhP" role="1BdPVh">
+                <ref role="3cqZAo" node="2oJmO5LUeTk" resolve="callee" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2oJmO5LUeOk" role="1B3o_S" />
+      <node concept="16syzq" id="2oJmO5LUeSR" role="3clF45">
+        <ref role="16sUi3" node="2oJmO5LUeSc" resolve="R" />
+      </node>
+      <node concept="16euLQ" id="2oJmO5LUeRL" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+      <node concept="16euLQ" id="2oJmO5LUeSc" role="16eVyc">
+        <property role="TrG5h" value="R" />
+      </node>
+      <node concept="37vLTG" id="2oJmO5LUeTk" role="3clF46">
+        <property role="TrG5h" value="callee" />
+        <node concept="16syzq" id="2oJmO5LUeTj" role="1tU5fm">
+          <ref role="16sUi3" node="2oJmO5LUeRL" resolve="T" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2oJmO5LUeTm" role="3clF46">
+        <property role="TrG5h" value="function" />
+        <node concept="1ajhzC" id="2oJmO5LUeTR" role="1tU5fm">
+          <node concept="16syzq" id="2oJmO5LUeUL" role="1ajl9A">
+            <ref role="16sUi3" node="2oJmO5LUeSc" resolve="R" />
+          </node>
+          <node concept="16syzq" id="2oJmO5LUeUk" role="1ajw0F">
+            <ref role="16sUi3" node="2oJmO5LUeRL" resolve="T" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2YIFZL" id="2oJmO5LUfj9" role="jymVt">
+      <property role="TrG5h" value="letVoid" />
+      <node concept="3clFbS" id="2oJmO5LUfja" role="3clF47">
+        <node concept="3clFbF" id="2oJmO5LUfjb" role="3cqZAp">
+          <node concept="2OqwBi" id="2oJmO5LUfjc" role="3clFbG">
+            <node concept="37vLTw" id="2oJmO5LUfjd" role="2Oq$k0">
+              <ref role="3cqZAo" node="2oJmO5LUfjm" resolve="function" />
+            </node>
+            <node concept="1Bd96e" id="2oJmO5LUfje" role="2OqNvi">
+              <node concept="37vLTw" id="2oJmO5LUfjf" role="1BdPVh">
+                <ref role="3cqZAo" node="2oJmO5LUfjk" resolve="callee" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2oJmO5LUfjg" role="1B3o_S" />
+      <node concept="3cqZAl" id="2oJmO5LUfoU" role="3clF45" />
+      <node concept="16euLQ" id="2oJmO5LUfji" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+      <node concept="37vLTG" id="2oJmO5LUfjk" role="3clF46">
+        <property role="TrG5h" value="callee" />
+        <node concept="16syzq" id="2oJmO5LUfjl" role="1tU5fm">
+          <ref role="16sUi3" node="2oJmO5LUfji" resolve="T" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2oJmO5LUfjm" role="3clF46">
+        <property role="TrG5h" value="function" />
+        <node concept="1ajhzC" id="2oJmO5LUfjn" role="1tU5fm">
+          <node concept="3cqZAl" id="2oJmO5LUfqj" role="1ajl9A" />
+          <node concept="16syzq" id="2oJmO5LUfjp" role="1ajw0F">
+            <ref role="16sUi3" node="2oJmO5LUfji" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="2aEySx" id="2oJmO5LZr1I" role="lGtFl">
+        <node concept="19SGf9" id="2oJmO5LZr1J" role="2aEySw">
+          <node concept="19SUe$" id="2oJmO5LZr1K" role="19SJt6">
+            <property role="19SUeA" value="This technically shouldn't be used explicitly, as it doesn't make much sense.&#10;But it is required to get the syntactic sugar variant type check and generate. " />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="2oJmO5LUej3" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
@@ -1491,6 +1491,87 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="4OYzber0qre" role="3cqZAp">
+          <node concept="2OqwBi" id="4OYzber0qS5" role="3clFbG">
+            <node concept="Xl_RD" id="4OYzber0qrd" role="2Oq$k0">
+              <property role="Xl_RC" value="test" />
+            </node>
+            <node concept="1kbSPS" id="4OYzber0r4O" role="2OqNvi">
+              <node concept="1bVj0M" id="4OYzber0raC" role="1kbSPQ">
+                <node concept="3clFbS" id="4OYzber0raE" role="1bW5cS" />
+                <node concept="3nFU9Y" id="4OYzber0XmH" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="4OYzber0XmI" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4OYzber0rrZ" role="3cqZAp">
+          <node concept="2OqwBi" id="4OYzber0tnQ" role="3clFbG">
+            <node concept="2ShNRf" id="4OYzber0rrV" role="2Oq$k0">
+              <node concept="Tc6Ow" id="4OYzber0rIm" role="2ShVmc">
+                <node concept="17QB3L" id="4OYzber0slS" role="HW$YZ" />
+              </node>
+            </node>
+            <node concept="3$u5V9" id="4OYzber0ufT" role="2OqNvi">
+              <node concept="1bVj0M" id="4OYzber0uvd" role="23t8la">
+                <node concept="3clFbS" id="4OYzber0uvf" role="1bW5cS" />
+                <node concept="Rh6nW" id="4OYzber0X$t" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="4OYzber0X$u" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4OYzber0XGF" role="3cqZAp" />
+        <node concept="3clFbF" id="4OYzber0XMg" role="3cqZAp">
+          <node concept="2OqwBi" id="4OYzber0Yf7" role="3clFbG">
+            <node concept="Xl_RD" id="4OYzber0XMf" role="2Oq$k0">
+              <property role="Xl_RC" value="Test" />
+            </node>
+            <node concept="1kbSPS" id="4OYzber0YwI" role="2OqNvi">
+              <node concept="1bVj0M" id="4OYzber0YwK" role="1kbSPQ">
+                <node concept="3clFbS" id="4OYzber0YwL" role="1bW5cS">
+                  <node concept="3clFbF" id="4OYzber0Y$9" role="3cqZAp">
+                    <node concept="2OqwBi" id="4OYzber10mU" role="3clFbG">
+                      <node concept="2ShNRf" id="4OYzber0Y$7" role="2Oq$k0">
+                        <node concept="Tc6Ow" id="4OYzber0YQV" role="2ShVmc">
+                          <node concept="17QB3L" id="4OYzber0Z_8" role="HW$YZ" />
+                        </node>
+                      </node>
+                      <node concept="3$u5V9" id="4OYzber11fU" role="2OqNvi">
+                        <node concept="1bVj0M" id="4OYzber7aX3" role="23t8la">
+                          <node concept="3clFbS" id="4OYzber7aX5" role="1bW5cS">
+                            <node concept="3clFbF" id="4OYzber7CJJ" role="3cqZAp">
+                              <node concept="3cpWs3" id="4OYzber7Ee_" role="3clFbG">
+                                <node concept="37vLTw" id="4OYzber7Ef8" role="3uHU7w">
+                                  <ref role="3cqZAo" node="4OYzber0YwM" resolve="outer" />
+                                </node>
+                                <node concept="37vLTw" id="4OYzber7CJI" role="3uHU7B">
+                                  <ref role="3cqZAo" node="4OYzber7Czi" resolve="it" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="4OYzber7Czi" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="4OYzber7Czj" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3nFU9Y" id="4OYzber0YwM" role="1bW2Oz">
+                  <property role="TrG5h" value="outer" />
+                  <node concept="2jxLKc" id="4OYzber0YwN" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbH" id="2oJmO5MkFel" role="3cqZAp" />
         <node concept="3clFbF" id="2oJmO5M1U_l" role="3cqZAp">
           <node concept="2OqwBi" id="2oJmO5M2lvm" role="3clFbG">

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
@@ -59,9 +59,11 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271484915" name="jetbrains.mps.baseLanguage.structure.SubstringExpression" flags="nn" index="17RM3I">
+        <child id="1225271484917" name="startIndex" index="17RM3C" />
         <child id="1225271484916" name="operand" index="17RM3D" />
         <child id="1225271484918" name="endIndex" index="17RM3F" />
       </concept>
+      <concept id="1225271546410" name="jetbrains.mps.baseLanguage.structure.TrimOperation" flags="nn" index="17S1cR" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -135,6 +137,12 @@
       <concept id="7915817776605258993" name="de.itemis.mps.baseLanguageExtensions.structure.SelectWithIndexOperation" flags="ng" index="2kBsqy" />
       <concept id="5842252078326680676" name="de.itemis.mps.baseLanguageExtensions.structure.GroupByOperation" flags="ng" index="2pSdkF" />
       <concept id="7488777117048605758" name="de.itemis.mps.baseLanguageExtensions.structure.ZipOperation" flags="ng" index="Kbfsy" />
+      <concept id="2751518233990321717" name="de.itemis.mps.baseLanguageExtensions.structure.ScopeFunctionOperation" flags="ng" index="1kbSPO">
+        <child id="2751518233990321719" name="closure" index="1kbSPQ" />
+      </concept>
+      <concept id="2751518233990321721" name="de.itemis.mps.baseLanguageExtensions.structure.ApplyScopeFunctionOperation" flags="ng" index="1kbSPS" />
+      <concept id="2751518233990321724" name="de.itemis.mps.baseLanguageExtensions.structure.LetScopeFunctionOperation" flags="ng" index="1kbSPX" />
+      <concept id="5566040892496752333" name="de.itemis.mps.baseLanguageExtensions.structure.SmartAtomicClosureParameterDeclaration" flags="ig" index="3nFU9Y" />
       <concept id="8919968723020343837" name="de.itemis.mps.baseLanguageExtensions.structure.ForEachWithIndexOperation" flags="ng" index="1sWJ9m" />
       <concept id="8919968723020245069" name="de.itemis.mps.baseLanguageExtensions.structure.WhereWithIndexOperation" flags="ng" index="1sZn06" />
       <concept id="578371460444482140" name="de.itemis.mps.baseLanguageExtensions.structure.ElvisOperation" flags="ng" index="1w0Eer" />
@@ -1250,8 +1258,8 @@
         <node concept="3clFbF" id="7Ja64GBeUXK" role="3cqZAp">
           <node concept="2OqwBi" id="7Ja64GBeUXH" role="3clFbG">
             <node concept="10M0yZ" id="7Ja64GBeUXI" role="2Oq$k0">
-              <ref role="1PxDUh" to="wyt6:~System" />
-              <ref role="3cqZAo" to="wyt6:~System.out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
             </node>
             <node concept="liA8E" id="7Ja64GBeUXJ" role="2OqNvi">
               <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.Object)" resolve="println" />
@@ -1271,7 +1279,7 @@
             <node concept="2OqwBi" id="7Ja64GBeNL_" role="33vP2m">
               <property role="hSjvv" value="true" />
               <node concept="37vLTw" id="7Ja64GBeOxn" role="2Oq$k0">
-                <ref role="3cqZAo" node="7Ja64GBeOxf" resolve="list" />
+                <ref role="3cqZAo" node="7Ja64GBeOxf" resolve="numsAsStrings" />
               </node>
               <node concept="1sZn06" id="7Ja64GBeNLH" role="2OqNvi">
                 <node concept="1bVj0M" id="7Ja64GBeNLI" role="23t8la">
@@ -1308,8 +1316,8 @@
         <node concept="3clFbF" id="7Ja64GBeOec" role="3cqZAp">
           <node concept="2OqwBi" id="7Ja64GBeOe9" role="3clFbG">
             <node concept="10M0yZ" id="7Ja64GBeOea" role="2Oq$k0">
-              <ref role="1PxDUh" to="wyt6:~System" />
-              <ref role="3cqZAo" to="wyt6:~System.out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
             </node>
             <node concept="liA8E" id="7Ja64GBeOeb" role="2OqNvi">
               <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.Object)" resolve="println" />
@@ -1332,8 +1340,8 @@
                   <node concept="3clFbF" id="7Ja64GBeXa7" role="3cqZAp">
                     <node concept="2OqwBi" id="7Ja64GBeXa4" role="3clFbG">
                       <node concept="10M0yZ" id="7Ja64GBeXa5" role="2Oq$k0">
-                        <ref role="1PxDUh" to="wyt6:~System" />
-                        <ref role="3cqZAo" to="wyt6:~System.out" />
+                        <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                        <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
                       </node>
                       <node concept="liA8E" id="7Ja64GBeXa6" role="2OqNvi">
                         <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
@@ -1376,6 +1384,127 @@
       <node concept="3cqZAl" id="7Ja64GBeFHy" role="3clF45" />
     </node>
     <node concept="3Tm1VV" id="7Ja64GBeFG7" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="2oJmO5M1vQc">
+    <property role="TrG5h" value="ScopeFunctionSandbox" />
+    <node concept="2YIFZL" id="2oJmO5M1vRw" role="jymVt">
+      <property role="TrG5h" value="usage" />
+      <node concept="3clFbS" id="2oJmO5M1vRz" role="3clF47">
+        <node concept="3cpWs8" id="2oJmO5M4ASK" role="3cqZAp">
+          <node concept="3cpWsn" id="2oJmO5M4ASL" role="3cpWs9">
+            <property role="TrG5h" value="string" />
+            <node concept="17QB3L" id="2oJmO5M4AQI" role="1tU5fm" />
+            <node concept="2OqwBi" id="2oJmO5M4ASM" role="33vP2m">
+              <node concept="Xl_RD" id="2oJmO5M4ASN" role="2Oq$k0">
+                <property role="Xl_RC" value="Test" />
+              </node>
+              <node concept="1kbSPS" id="2oJmO5M4ASO" role="2OqNvi">
+                <node concept="1bVj0M" id="2oJmO5M4ASP" role="1kbSPQ">
+                  <node concept="37vLTG" id="2oJmO5M4ASQ" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="17QB3L" id="2oJmO5M4ASR" role="1tU5fm" />
+                  </node>
+                  <node concept="3clFbS" id="2oJmO5M4ASS" role="1bW5cS">
+                    <node concept="3clFbF" id="2oJmO5M4AST" role="3cqZAp">
+                      <node concept="2OqwBi" id="2oJmO5M4ASU" role="3clFbG">
+                        <node concept="37vLTw" id="2oJmO5M4ASV" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2oJmO5M4ASQ" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="2oJmO5M4ASW" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2oJmO5M54P1" role="3cqZAp">
+          <node concept="3cpWsn" id="2oJmO5M54P2" role="3cpWs9">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="2oJmO5M54Cw" role="1tU5fm" />
+            <node concept="2OqwBi" id="2oJmO5M54P3" role="33vP2m">
+              <node concept="Xl_RD" id="2oJmO5M54P4" role="2Oq$k0">
+                <property role="Xl_RC" value="Test" />
+              </node>
+              <node concept="1kbSPX" id="2oJmO5M54P5" role="2OqNvi">
+                <node concept="1bVj0M" id="2oJmO5M54P6" role="1kbSPQ">
+                  <node concept="37vLTG" id="2oJmO5M54P7" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="17QB3L" id="2oJmO5M54P8" role="1tU5fm" />
+                  </node>
+                  <node concept="3clFbS" id="2oJmO5M54P9" role="1bW5cS">
+                    <node concept="3clFbF" id="2oJmO5M54Pa" role="3cqZAp">
+                      <node concept="2OqwBi" id="2oJmO5M54Pb" role="3clFbG">
+                        <node concept="37vLTw" id="2oJmO5M54Pc" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2oJmO5M54P7" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="2oJmO5M54Pd" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4OYzbeq$4t9" role="3cqZAp">
+          <node concept="2OqwBi" id="4OYzbeq$4Si" role="3clFbG">
+            <node concept="Xl_RD" id="4OYzbeq$4t8" role="2Oq$k0">
+              <property role="Xl_RC" value="Text" />
+            </node>
+            <node concept="1kbSPS" id="4OYzbeqB09M" role="2OqNvi">
+              <node concept="1bVj0M" id="4OYzbeqB09O" role="1kbSPQ">
+                <node concept="3clFbS" id="4OYzbeqB09P" role="1bW5cS">
+                  <node concept="3clFbF" id="4OYzbeqCCWw" role="3cqZAp">
+                    <node concept="2OqwBi" id="4OYzbeqCDkV" role="3clFbG">
+                      <node concept="10M0yZ" id="4OYzbeqCCWE" role="2Oq$k0">
+                        <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                        <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                      </node>
+                      <node concept="liA8E" id="4OYzbeqCD_d" role="2OqNvi">
+                        <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                        <node concept="17RM3I" id="4OYzbeqCEUj" role="37wK5m">
+                          <node concept="37vLTw" id="4OYzbeqCDCt" role="17RM3D">
+                            <ref role="3cqZAo" node="4OYzbeqB09Q" resolve="it" />
+                          </node>
+                          <node concept="3cmrfG" id="4OYzbeqCF5s" role="17RM3C">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                          <node concept="3cmrfG" id="4OYzbeqCF8Z" role="17RM3F">
+                            <property role="3cmrfH" value="3" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3nFU9Y" id="4OYzbeqB09Q" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="4OYzbeqB09R" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2oJmO5MkFel" role="3cqZAp" />
+        <node concept="3clFbF" id="2oJmO5M1U_l" role="3cqZAp">
+          <node concept="2OqwBi" id="2oJmO5M2lvm" role="3clFbG">
+            <node concept="Xl_RD" id="2oJmO5M1U_k" role="2Oq$k0">
+              <property role="Xl_RC" value="Test" />
+            </node>
+            <node concept="17S1cR" id="2oJmO5M2lD8" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2oJmO5M1vR9" role="1B3o_S" />
+      <node concept="3cqZAl" id="2oJmO5M1vRm" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="2oJmO5M1vQd" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
@@ -428,7 +428,7 @@
           </node>
           <node concept="10Nm6u" id="54jQkZ9fKdF" role="37wK5m">
             <node concept="1sPUBX" id="54jQkZ9fKkf" role="lGtFl">
-              <ref role="v9R2y" node="54jQkZ9fKWX" resolve="GroupByOperation" />
+              <ref role="v9R2y" node="54jQkZ9fKWX" resolve="switchClosureLiteral" />
               <node concept="3NFfHV" id="54jQkZ9ghak" role="1sPUBK">
                 <node concept="3clFbS" id="54jQkZ9ghal" role="2VODD2">
                   <node concept="3clFbF" id="54jQkZ9ghe5" role="3cqZAp">
@@ -480,7 +480,7 @@
       <node concept="gft3U" id="7Ja64GBaq9Z" role="1lVwrX">
         <node concept="2YIFZM" id="7Ja64GBar5T" role="gfFT$">
           <ref role="37wK5l" to="96gm:7Ja64GBadQG" resolve="selectWithIndex" />
-          <ref role="1Pybhc" to="96gm:7Ja64GBadPz" resolve="SelectWithIndexOperationUtil" />
+          <ref role="1Pybhc" to="96gm:7Ja64GBadPz" resolve="WithIndexOperationUtil" />
           <node concept="10Nm6u" id="7Ja64GBar5U" role="37wK5m">
             <node concept="29HgVG" id="7Ja64GBar5V" role="lGtFl">
               <node concept="3NFfHV" id="7Ja64GBar5W" role="3NFExx">
@@ -499,7 +499,7 @@
           </node>
           <node concept="10Nm6u" id="7Ja64GBar62" role="37wK5m">
             <node concept="1sPUBX" id="7Ja64GBar63" role="lGtFl">
-              <ref role="v9R2y" node="54jQkZ9fKWX" resolve="GroupByOperation" />
+              <ref role="v9R2y" node="54jQkZ9fKWX" resolve="switchClosureLiteral" />
               <node concept="3NFfHV" id="7Ja64GBar6b" role="1sPUBK">
                 <node concept="3clFbS" id="7Ja64GBar6c" role="2VODD2">
                   <node concept="3clFbF" id="7Ja64GBar6d" role="3cqZAp">
@@ -688,9 +688,342 @@
         </node>
       </node>
     </node>
+    <node concept="3aamgX" id="2oJmO5M55Or" role="3acgRq">
+      <ref role="30HIoZ" to="tpee:hqOqwz4" resolve="DotExpression" />
+      <node concept="gft3U" id="2oJmO5M57Ad" role="1lVwrX">
+        <node concept="2YIFZM" id="2oJmO5M5beM" role="gfFT$">
+          <ref role="37wK5l" to="96gm:2oJmO5LXrKn" resolve="applyVoid" />
+          <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+          <node concept="1W57fq" id="2oJmO5M5beN" role="lGtFl">
+            <node concept="3IZrLx" id="2oJmO5M5beO" role="3IZSJc">
+              <node concept="3clFbS" id="2oJmO5M5beP" role="2VODD2">
+                <node concept="3clFbF" id="2oJmO5M5beQ" role="3cqZAp">
+                  <node concept="2OqwBi" id="2oJmO5M5beR" role="3clFbG">
+                    <node concept="2OqwBi" id="2oJmO5M5beS" role="2Oq$k0">
+                      <node concept="1PxgMI" id="2oJmO5M5beT" role="2Oq$k0">
+                        <node concept="chp4Y" id="2oJmO5M5beU" role="3oSUPX">
+                          <ref role="cht4Q" to="tp2c:htajhBZ" resolve="FunctionType" />
+                        </node>
+                        <node concept="2OqwBi" id="2oJmO5M5beV" role="1m5AlR">
+                          <node concept="2OqwBi" id="2oJmO5Mi59l" role="2Oq$k0">
+                            <node concept="1PxgMI" id="2oJmO5Mi4HA" role="2Oq$k0">
+                              <node concept="chp4Y" id="2oJmO5Mi4YS" role="3oSUPX">
+                                <ref role="cht4Q" to="pkab:2oJmO5M0doT" resolve="ApplyScopeFunctionOperation" />
+                              </node>
+                              <node concept="2OqwBi" id="2oJmO5M5beW" role="1m5AlR">
+                                <node concept="3TrEf2" id="2oJmO5M5beX" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                                </node>
+                                <node concept="30H73N" id="2oJmO5M5beY" role="2Oq$k0" />
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="2oJmO5Mi5yq" role="2OqNvi">
+                              <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+                            </node>
+                          </node>
+                          <node concept="3JvlWi" id="2oJmO5M5beZ" role="2OqNvi" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="2oJmO5M5bf0" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tp2c:htajldL" resolve="resultType" />
+                      </node>
+                    </node>
+                    <node concept="1mIQ4w" id="2oJmO5M5bf1" role="2OqNvi">
+                      <node concept="chp4Y" id="2oJmO5M5bf2" role="cj9EA">
+                        <ref role="cht4Q" to="tpee:fzcqZ_H" resolve="VoidType" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="gft3U" id="2oJmO5M5bf3" role="UU_$l">
+              <node concept="2YIFZM" id="2oJmO5M5bhc" role="gfFT$">
+                <ref role="37wK5l" to="96gm:2oJmO5LUek_" resolve="apply" />
+                <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+                <node concept="10Nm6u" id="2oJmO5M7f2i" role="37wK5m">
+                  <node concept="29HgVG" id="2oJmO5M7f2j" role="lGtFl">
+                    <node concept="3NFfHV" id="2oJmO5M7f2k" role="3NFExx">
+                      <node concept="3clFbS" id="2oJmO5M7f2l" role="2VODD2">
+                        <node concept="3clFbF" id="2oJmO5M7f2m" role="3cqZAp">
+                          <node concept="2OqwBi" id="2oJmO5M7f2n" role="3clFbG">
+                            <node concept="30H73N" id="2oJmO5M7f2o" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="2oJmO5M7f2p" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="10Nm6u" id="2oJmO5M5cfb" role="37wK5m">
+                  <node concept="1sPUBX" id="4OYzbeqyZ5C" role="lGtFl">
+                    <ref role="v9R2y" node="54jQkZ9fKWX" resolve="switchClosureLiteral" />
+                    <node concept="3NFfHV" id="4OYzbeqz1eH" role="1sPUBK">
+                      <node concept="3clFbS" id="4OYzbeqz1eI" role="2VODD2">
+                        <node concept="3clFbF" id="4OYzbeqz1eJ" role="3cqZAp">
+                          <node concept="2OqwBi" id="4OYzbeqz1eK" role="3clFbG">
+                            <node concept="1PxgMI" id="4OYzbeqz1eL" role="2Oq$k0">
+                              <node concept="chp4Y" id="4OYzbeqz1eM" role="3oSUPX">
+                                <ref role="cht4Q" to="pkab:2oJmO5M0doT" resolve="ApplyScopeFunctionOperation" />
+                              </node>
+                              <node concept="2OqwBi" id="4OYzbeqz1eN" role="1m5AlR">
+                                <node concept="30H73N" id="4OYzbeqz1eO" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="4OYzbeqz1eP" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="4OYzbeqz1eQ" role="2OqNvi">
+                              <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="10Nm6u" id="2oJmO5M7f7v" role="37wK5m">
+            <node concept="29HgVG" id="2oJmO5M7f7w" role="lGtFl">
+              <node concept="3NFfHV" id="2oJmO5M7f7x" role="3NFExx">
+                <node concept="3clFbS" id="2oJmO5M7f7y" role="2VODD2">
+                  <node concept="3clFbF" id="2oJmO5M7f7z" role="3cqZAp">
+                    <node concept="2OqwBi" id="2oJmO5M7f7$" role="3clFbG">
+                      <node concept="30H73N" id="2oJmO5M7f7_" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="2oJmO5M7f7A" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="10Nm6u" id="2oJmO5M5bXg" role="37wK5m">
+            <node concept="1sPUBX" id="4OYzbeqyZ1m" role="lGtFl">
+              <ref role="v9R2y" node="54jQkZ9fKWX" resolve="switchClosureLiteral" />
+              <node concept="3NFfHV" id="4OYzbeqyZcv" role="1sPUBK">
+                <node concept="3clFbS" id="4OYzbeqyZcw" role="2VODD2">
+                  <node concept="3clFbF" id="4OYzbeqyZdg" role="3cqZAp">
+                    <node concept="2OqwBi" id="4OYzbeqz0ue" role="3clFbG">
+                      <node concept="1PxgMI" id="4OYzbeqz0b0" role="2Oq$k0">
+                        <node concept="chp4Y" id="4OYzbeqz0bY" role="3oSUPX">
+                          <ref role="cht4Q" to="pkab:2oJmO5M0doT" resolve="ApplyScopeFunctionOperation" />
+                        </node>
+                        <node concept="2OqwBi" id="4OYzbeqyZEs" role="1m5AlR">
+                          <node concept="30H73N" id="4OYzbeqyZdf" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="4OYzbeqyZZh" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="4OYzbeqz18j" role="2OqNvi">
+                        <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="2oJmO5M564Q" role="30HLyM">
+        <node concept="3clFbS" id="2oJmO5M564R" role="2VODD2">
+          <node concept="3clFbF" id="2oJmO5M56m7" role="3cqZAp">
+            <node concept="2OqwBi" id="2oJmO5M57af" role="3clFbG">
+              <node concept="2OqwBi" id="2oJmO5M56DI" role="2Oq$k0">
+                <node concept="30H73N" id="2oJmO5M56m6" role="2Oq$k0" />
+                <node concept="3TrEf2" id="2oJmO5M56X_" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="2oJmO5M57zv" role="2OqNvi">
+                <node concept="chp4Y" id="2oJmO5M57$s" role="cj9EA">
+                  <ref role="cht4Q" to="pkab:2oJmO5M0doT" resolve="ApplyScopeFunctionOperation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="2oJmO5M57Be" role="3acgRq">
+      <ref role="30HIoZ" to="tpee:hqOqwz4" resolve="DotExpression" />
+      <node concept="gft3U" id="2oJmO5M57Bf" role="1lVwrX">
+        <node concept="2YIFZM" id="2oJmO5M5bUr" role="gfFT$">
+          <ref role="37wK5l" to="96gm:2oJmO5LUfj9" resolve="letVoid" />
+          <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+          <node concept="10Nm6u" id="2oJmO5M7eX8" role="37wK5m">
+            <node concept="29HgVG" id="2oJmO5M7eX9" role="lGtFl">
+              <node concept="3NFfHV" id="2oJmO5M7eXa" role="3NFExx">
+                <node concept="3clFbS" id="2oJmO5M7eXb" role="2VODD2">
+                  <node concept="3clFbF" id="2oJmO5M7eXc" role="3cqZAp">
+                    <node concept="2OqwBi" id="2oJmO5M7eXd" role="3clFbG">
+                      <node concept="30H73N" id="2oJmO5M7eXe" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="2oJmO5M7eXf" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="10Nm6u" id="2oJmO5M5cfY" role="37wK5m">
+            <node concept="1sPUBX" id="4OYzbeqyZ6Z" role="lGtFl">
+              <ref role="v9R2y" node="54jQkZ9fKWX" resolve="switchClosureLiteral" />
+              <node concept="3NFfHV" id="4OYzbeqz1ml" role="1sPUBK">
+                <node concept="3clFbS" id="4OYzbeqz1mm" role="2VODD2">
+                  <node concept="3clFbF" id="4OYzbeqz1mn" role="3cqZAp">
+                    <node concept="2OqwBi" id="4OYzbeqz1mo" role="3clFbG">
+                      <node concept="1PxgMI" id="4OYzbeqz1mp" role="2Oq$k0">
+                        <node concept="chp4Y" id="4OYzbeqz1mq" role="3oSUPX">
+                          <ref role="cht4Q" to="pkab:2oJmO5M0doW" resolve="LetScopeFunctionOperation" />
+                        </node>
+                        <node concept="2OqwBi" id="4OYzbeqz1mr" role="1m5AlR">
+                          <node concept="30H73N" id="4OYzbeqz1ms" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="4OYzbeqz1mt" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="4OYzbeqz1mu" role="2OqNvi">
+                        <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1W57fq" id="2oJmO5M5bUs" role="lGtFl">
+            <node concept="3IZrLx" id="2oJmO5M5bUt" role="3IZSJc">
+              <node concept="3clFbS" id="2oJmO5M5bUu" role="2VODD2">
+                <node concept="3clFbF" id="2oJmO5M5bUv" role="3cqZAp">
+                  <node concept="2OqwBi" id="2oJmO5M5bUw" role="3clFbG">
+                    <node concept="2OqwBi" id="2oJmO5M5bUx" role="2Oq$k0">
+                      <node concept="1PxgMI" id="2oJmO5M5bUy" role="2Oq$k0">
+                        <node concept="chp4Y" id="2oJmO5M5bUz" role="3oSUPX">
+                          <ref role="cht4Q" to="tp2c:htajhBZ" resolve="FunctionType" />
+                        </node>
+                        <node concept="2OqwBi" id="2oJmO5M5bU$" role="1m5AlR">
+                          <node concept="3JvlWi" id="2oJmO5M5bUC" role="2OqNvi" />
+                          <node concept="2OqwBi" id="2oJmO5Mi5Am" role="2Oq$k0">
+                            <node concept="1PxgMI" id="2oJmO5Mi5An" role="2Oq$k0">
+                              <node concept="chp4Y" id="2oJmO5Mi5Ao" role="3oSUPX">
+                                <ref role="cht4Q" to="pkab:2oJmO5M0doW" resolve="LetScopeFunctionOperation" />
+                              </node>
+                              <node concept="2OqwBi" id="2oJmO5Mi5Ap" role="1m5AlR">
+                                <node concept="3TrEf2" id="2oJmO5Mi5Aq" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                                </node>
+                                <node concept="30H73N" id="2oJmO5Mi5Ar" role="2Oq$k0" />
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="2oJmO5Mi5As" role="2OqNvi">
+                              <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="2oJmO5M5bUD" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tp2c:htajldL" resolve="resultType" />
+                      </node>
+                    </node>
+                    <node concept="1mIQ4w" id="2oJmO5M5bUE" role="2OqNvi">
+                      <node concept="chp4Y" id="2oJmO5M5bUF" role="cj9EA">
+                        <ref role="cht4Q" to="tpee:fzcqZ_H" resolve="VoidType" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="gft3U" id="2oJmO5M5bUG" role="UU_$l">
+              <node concept="2YIFZM" id="2oJmO5M5bUH" role="gfFT$">
+                <ref role="37wK5l" to="96gm:2oJmO5LUeQ4" resolve="let" />
+                <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+                <node concept="10Nm6u" id="2oJmO5M5cxQ" role="37wK5m">
+                  <node concept="29HgVG" id="2oJmO5M5czb" role="lGtFl">
+                    <node concept="3NFfHV" id="2oJmO5M5czM" role="3NFExx">
+                      <node concept="3clFbS" id="2oJmO5M5czN" role="2VODD2">
+                        <node concept="3clFbF" id="2oJmO5M5cD2" role="3cqZAp">
+                          <node concept="2OqwBi" id="2oJmO5M5d7I" role="3clFbG">
+                            <node concept="30H73N" id="2oJmO5M5cD1" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="2oJmO5M7ebg" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="10Nm6u" id="2oJmO5M5cxR" role="37wK5m">
+                  <node concept="1sPUBX" id="4OYzbeqyZbc" role="lGtFl">
+                    <ref role="v9R2y" node="54jQkZ9fKWX" resolve="switchClosureLiteral" />
+                    <node concept="3NFfHV" id="4OYzbeqz1NY" role="1sPUBK">
+                      <node concept="3clFbS" id="4OYzbeqz1NZ" role="2VODD2">
+                        <node concept="3clFbF" id="4OYzbeqz1O0" role="3cqZAp">
+                          <node concept="2OqwBi" id="4OYzbeqz1O1" role="3clFbG">
+                            <node concept="1PxgMI" id="4OYzbeqz1O2" role="2Oq$k0">
+                              <node concept="chp4Y" id="4OYzbeqz1O3" role="3oSUPX">
+                                <ref role="cht4Q" to="pkab:2oJmO5M0doW" resolve="LetScopeFunctionOperation" />
+                              </node>
+                              <node concept="2OqwBi" id="4OYzbeqz1O4" role="1m5AlR">
+                                <node concept="30H73N" id="4OYzbeqz1O5" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="4OYzbeqz1O6" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="4OYzbeqz1O7" role="2OqNvi">
+                              <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="2oJmO5M57Bh" role="30HLyM">
+        <node concept="3clFbS" id="2oJmO5M57Bi" role="2VODD2">
+          <node concept="3clFbF" id="2oJmO5M57Bj" role="3cqZAp">
+            <node concept="2OqwBi" id="2oJmO5M57Bk" role="3clFbG">
+              <node concept="2OqwBi" id="2oJmO5M57Bl" role="2Oq$k0">
+                <node concept="30H73N" id="2oJmO5M57Bm" role="2Oq$k0" />
+                <node concept="3TrEf2" id="2oJmO5M57Bn" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="2oJmO5M57Bo" role="2OqNvi">
+                <node concept="chp4Y" id="2oJmO5M57Bp" role="cj9EA">
+                  <ref role="cht4Q" to="pkab:2oJmO5M0doW" resolve="LetScopeFunctionOperation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="jVnub" id="54jQkZ9fKWX">
     <property role="TrG5h" value="switchClosureLiteral" />
+    <node concept="gft3U" id="54jQkZ9g94P" role="jxRDz">
+      <node concept="10Nm6u" id="54jQkZ9g97V" role="gfFT$">
+        <node concept="29HgVG" id="54jQkZ9g984" role="lGtFl" />
+      </node>
+    </node>
     <node concept="3aamgX" id="7Ja64GBawMh" role="3aUrZf">
       <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
@@ -845,11 +1178,6 @@
             </node>
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="gft3U" id="54jQkZ9g94P" role="jxRDz">
-      <node concept="10Nm6u" id="54jQkZ9g97V" role="gfFT$">
-        <node concept="29HgVG" id="54jQkZ9g984" role="lGtFl" />
       </node>
     </node>
   </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.actions.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.actions.mps
@@ -374,7 +374,7 @@
                       <node concept="2OqwBi" id="7Ja64GB9RLQ" role="3clFbG">
                         <node concept="2OqwBi" id="7Ja64GB9NTc" role="2Oq$k0">
                           <node concept="37vLTw" id="7Ja64GB9Nw8" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7Ja64GB9JEq" resolve="pDecl" />
+                            <ref role="3cqZAo" node="7Ja64GB9JEq" resolve="pDeclIt" />
                           </node>
                           <node concept="3TrcHB" id="7Ja64GB9Omk" role="2OqNvi">
                             <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
@@ -844,6 +844,278 @@
                       <ref role="3cqZAo" node="7Ja64GBei$J" resolve="sel" />
                     </node>
                     <node concept="3w_OXm" id="7Ja64GBei_F" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="37WguZ" id="2oJmO5MktDH">
+    <property role="TrG5h" value="ScopeFunction_operations" />
+    <property role="3GE5qa" value="scopeFunction" />
+    <node concept="37WvkG" id="2oJmO5MkuVJ" role="37WGs$">
+      <ref role="37XkoT" to="pkab:2oJmO5M0doT" resolve="ApplyScopeFunctionOperation" />
+      <node concept="37Y9Zx" id="2oJmO5MkuVK" role="37ZfLb">
+        <node concept="3clFbS" id="2oJmO5MkuVL" role="2VODD2">
+          <node concept="3clFbJ" id="2oJmO5MkuWm" role="3cqZAp">
+            <node concept="3clFbS" id="2oJmO5MkuWn" role="3clFbx">
+              <node concept="3clFbF" id="2oJmO5MkuWo" role="3cqZAp">
+                <node concept="2OqwBi" id="2oJmO5MkuWp" role="3clFbG">
+                  <node concept="2OqwBi" id="2oJmO5MkuWq" role="2Oq$k0">
+                    <node concept="1r4Lsj" id="2oJmO5MkuWr" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="2oJmO5MkuWs" role="2OqNvi">
+                      <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+                    </node>
+                  </node>
+                  <node concept="2oxUTD" id="2oJmO5MkuWt" role="2OqNvi">
+                    <node concept="2OqwBi" id="2oJmO5MkuWu" role="2oxUTC">
+                      <node concept="2OqwBi" id="2oJmO5MkuWv" role="2Oq$k0">
+                        <node concept="1PxgMI" id="2oJmO5MkuWw" role="2Oq$k0">
+                          <node concept="1r4N5L" id="2oJmO5MkuWx" role="1m5AlR" />
+                          <node concept="chp4Y" id="2oJmO5MkuWy" role="3oSUPX">
+                            <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="2oJmO5MkuWz" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                        </node>
+                      </node>
+                      <node concept="3YRAZt" id="2oJmO5MkuW$" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2oJmO5MkuW_" role="3clFbw">
+              <node concept="1r4N5L" id="2oJmO5MkuWA" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="2oJmO5MkuWB" role="2OqNvi">
+                <node concept="chp4Y" id="2oJmO5MkuWC" role="cj9EA">
+                  <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                </node>
+              </node>
+            </node>
+            <node concept="9aQIb" id="2oJmO5MkuWD" role="9aQIa">
+              <node concept="3clFbS" id="2oJmO5MkuWE" role="9aQI4">
+                <node concept="3cpWs8" id="2oJmO5MkuWF" role="3cqZAp">
+                  <node concept="3cpWsn" id="2oJmO5MkuWG" role="3cpWs9">
+                    <property role="TrG5h" value="sel" />
+                    <node concept="3Tqbb2" id="2oJmO5MkuWH" role="1tU5fm">
+                      <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+                    </node>
+                    <node concept="2OqwBi" id="2oJmO5MkuWI" role="33vP2m">
+                      <node concept="1r4Lsj" id="2oJmO5MkuWJ" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="2oJmO5MkuWK" role="2OqNvi">
+                        <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="2oJmO5MkuWL" role="3cqZAp">
+                  <node concept="3clFbS" id="2oJmO5MkuWM" role="3clFbx">
+                    <node concept="3clFbF" id="2oJmO5MkuWN" role="3cqZAp">
+                      <node concept="37vLTI" id="2oJmO5MkuWO" role="3clFbG">
+                        <node concept="2OqwBi" id="2oJmO5MkuWP" role="37vLTx">
+                          <node concept="2OqwBi" id="2oJmO5MkuWQ" role="2Oq$k0">
+                            <node concept="1r4Lsj" id="2oJmO5MkuWR" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="2oJmO5MkuWS" role="2OqNvi">
+                              <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+                            </node>
+                          </node>
+                          <node concept="2DeJnY" id="2oJmO5MkuWT" role="2OqNvi">
+                            <ref role="1A9B2P" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="2oJmO5MkuWU" role="37vLTJ">
+                          <ref role="3cqZAo" node="2oJmO5MkuWG" resolve="sel" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="2oJmO5MkuWV" role="3clFbw">
+                    <node concept="37vLTw" id="2oJmO5MkuWW" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2oJmO5MkuWG" resolve="sel" />
+                    </node>
+                    <node concept="3w_OXm" id="2oJmO5MkuWX" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="2oJmO5MkuWY" role="3cqZAp">
+                  <node concept="3cpWsn" id="2oJmO5MkuWZ" role="3cpWs9">
+                    <property role="TrG5h" value="pd" />
+                    <node concept="3Tqbb2" id="2oJmO5MkuX0" role="1tU5fm">
+                      <ref role="ehGHo" to="pkab:4OYzbeq$iVd" resolve="SmartAtomicClosureParameterDeclaration" />
+                    </node>
+                    <node concept="2OqwBi" id="2oJmO5MkuX1" role="33vP2m">
+                      <node concept="2OqwBi" id="2oJmO5MkuX2" role="2Oq$k0">
+                        <node concept="1PxgMI" id="2oJmO5MkuX3" role="2Oq$k0">
+                          <node concept="37vLTw" id="2oJmO5MkuX4" role="1m5AlR">
+                            <ref role="3cqZAo" node="2oJmO5MkuWG" resolve="sel" />
+                          </node>
+                          <node concept="chp4Y" id="2oJmO5MkuX5" role="3oSUPX">
+                            <ref role="cht4Q" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                          </node>
+                        </node>
+                        <node concept="3Tsc0h" id="2oJmO5MkuX6" role="2OqNvi">
+                          <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                        </node>
+                      </node>
+                      <node concept="2DeJg1" id="2oJmO5MkuX7" role="2OqNvi">
+                        <ref role="1A0vxQ" to="pkab:4OYzbeq$iVd" resolve="SmartAtomicClosureParameterDeclaration" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="2oJmO5MkuX8" role="3cqZAp">
+                  <node concept="2OqwBi" id="2oJmO5MkuX9" role="3clFbG">
+                    <node concept="2OqwBi" id="2oJmO5MkuXa" role="2Oq$k0">
+                      <node concept="37vLTw" id="2oJmO5MkuXb" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2oJmO5MkuWZ" resolve="pd" />
+                      </node>
+                      <node concept="3TrcHB" id="2oJmO5MkuXc" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                    <node concept="tyxLq" id="2oJmO5MkuXd" role="2OqNvi">
+                      <node concept="Xl_RD" id="2oJmO5MkuXe" role="tz02z">
+                        <property role="Xl_RC" value="it" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="37WvkG" id="2oJmO5MkuW2" role="37WGs$">
+      <ref role="37XkoT" to="pkab:2oJmO5M0doW" resolve="LetScopeFunctionOperation" />
+      <node concept="37Y9Zx" id="2oJmO5MkuW3" role="37ZfLb">
+        <node concept="3clFbS" id="2oJmO5MkuW4" role="2VODD2">
+          <node concept="3clFbJ" id="2oJmO5Mkwjy" role="3cqZAp">
+            <node concept="3clFbS" id="2oJmO5Mkwjz" role="3clFbx">
+              <node concept="3clFbF" id="2oJmO5Mkwj$" role="3cqZAp">
+                <node concept="2OqwBi" id="2oJmO5Mkwj_" role="3clFbG">
+                  <node concept="2OqwBi" id="2oJmO5MkwjA" role="2Oq$k0">
+                    <node concept="1r4Lsj" id="2oJmO5MkwjB" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="2oJmO5MkwjC" role="2OqNvi">
+                      <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+                    </node>
+                  </node>
+                  <node concept="2oxUTD" id="2oJmO5MkwjD" role="2OqNvi">
+                    <node concept="2OqwBi" id="2oJmO5MkwjE" role="2oxUTC">
+                      <node concept="2OqwBi" id="2oJmO5MkwjF" role="2Oq$k0">
+                        <node concept="1PxgMI" id="2oJmO5MkwjG" role="2Oq$k0">
+                          <node concept="1r4N5L" id="2oJmO5MkwjH" role="1m5AlR" />
+                          <node concept="chp4Y" id="2oJmO5MkwjI" role="3oSUPX">
+                            <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="2oJmO5MkwjJ" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
+                        </node>
+                      </node>
+                      <node concept="3YRAZt" id="2oJmO5MkwjK" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2oJmO5MkwjL" role="3clFbw">
+              <node concept="1r4N5L" id="2oJmO5MkwjM" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="2oJmO5MkwjN" role="2OqNvi">
+                <node concept="chp4Y" id="2oJmO5MkwjO" role="cj9EA">
+                  <ref role="cht4Q" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+                </node>
+              </node>
+            </node>
+            <node concept="9aQIb" id="2oJmO5MkwjP" role="9aQIa">
+              <node concept="3clFbS" id="2oJmO5MkwjQ" role="9aQI4">
+                <node concept="3cpWs8" id="2oJmO5MkwjR" role="3cqZAp">
+                  <node concept="3cpWsn" id="2oJmO5MkwjS" role="3cpWs9">
+                    <property role="TrG5h" value="sel" />
+                    <node concept="3Tqbb2" id="2oJmO5MkwjT" role="1tU5fm">
+                      <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+                    </node>
+                    <node concept="2OqwBi" id="2oJmO5MkwjU" role="33vP2m">
+                      <node concept="1r4Lsj" id="2oJmO5MkwjV" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="2oJmO5MkwjW" role="2OqNvi">
+                        <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="2oJmO5MkwjX" role="3cqZAp">
+                  <node concept="3clFbS" id="2oJmO5MkwjY" role="3clFbx">
+                    <node concept="3clFbF" id="2oJmO5MkwjZ" role="3cqZAp">
+                      <node concept="37vLTI" id="2oJmO5Mkwk0" role="3clFbG">
+                        <node concept="2OqwBi" id="2oJmO5Mkwk1" role="37vLTx">
+                          <node concept="2OqwBi" id="2oJmO5Mkwk2" role="2Oq$k0">
+                            <node concept="1r4Lsj" id="2oJmO5Mkwk3" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="2oJmO5Mkwk4" role="2OqNvi">
+                              <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+                            </node>
+                          </node>
+                          <node concept="2DeJnY" id="2oJmO5Mkwk5" role="2OqNvi">
+                            <ref role="1A9B2P" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="2oJmO5Mkwk6" role="37vLTJ">
+                          <ref role="3cqZAo" node="2oJmO5MkwjS" resolve="sel" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="2oJmO5Mkwk7" role="3clFbw">
+                    <node concept="37vLTw" id="2oJmO5Mkwk8" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2oJmO5MkwjS" resolve="sel" />
+                    </node>
+                    <node concept="3w_OXm" id="2oJmO5Mkwk9" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="2oJmO5Mkwka" role="3cqZAp">
+                  <node concept="3cpWsn" id="2oJmO5Mkwkb" role="3cpWs9">
+                    <property role="TrG5h" value="pd" />
+                    <node concept="3Tqbb2" id="2oJmO5Mkwkc" role="1tU5fm">
+                      <ref role="ehGHo" to="pkab:4OYzbeq$iVd" resolve="SmartAtomicClosureParameterDeclaration" />
+                    </node>
+                    <node concept="2OqwBi" id="2oJmO5Mkwkd" role="33vP2m">
+                      <node concept="2OqwBi" id="2oJmO5Mkwke" role="2Oq$k0">
+                        <node concept="1PxgMI" id="2oJmO5Mkwkf" role="2Oq$k0">
+                          <node concept="37vLTw" id="2oJmO5Mkwkg" role="1m5AlR">
+                            <ref role="3cqZAo" node="2oJmO5MkwjS" resolve="sel" />
+                          </node>
+                          <node concept="chp4Y" id="2oJmO5Mkwkh" role="3oSUPX">
+                            <ref role="cht4Q" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                          </node>
+                        </node>
+                        <node concept="3Tsc0h" id="2oJmO5Mkwki" role="2OqNvi">
+                          <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                        </node>
+                      </node>
+                      <node concept="2DeJg1" id="2oJmO5Mkwkj" role="2OqNvi">
+                        <ref role="1A0vxQ" to="pkab:4OYzbeq$iVd" resolve="SmartAtomicClosureParameterDeclaration" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="2oJmO5Mkwkk" role="3cqZAp">
+                  <node concept="2OqwBi" id="2oJmO5Mkwkl" role="3clFbG">
+                    <node concept="2OqwBi" id="2oJmO5Mkwkm" role="2Oq$k0">
+                      <node concept="37vLTw" id="2oJmO5Mkwkn" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2oJmO5Mkwkb" resolve="pd" />
+                      </node>
+                      <node concept="3TrcHB" id="2oJmO5Mkwko" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                    <node concept="tyxLq" id="2oJmO5Mkwkp" role="2OqNvi">
+                      <node concept="Xl_RD" id="2oJmO5Mkwkq" role="tz02z">
+                        <property role="Xl_RC" value="it" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.constraints.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.constraints.mps
@@ -7,9 +7,13 @@
   </languages>
   <imports>
     <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
+    <import index="tp2c" ref="r:00000000-0000-4000-0000-011c89590338(jetbrains.mps.baseLanguage.closures.structure)" implicit="true" />
+    <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -17,18 +21,40 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
     </language>
     <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
       <concept id="6702802731807351367" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAChild" flags="in" index="9S07l" />
+      <concept id="6702802731807424858" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAnAncestor" flags="in" index="9SQb8" />
       <concept id="1202989658459" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_parentNode" flags="nn" index="nLn13" />
+      <concept id="4303308395523096213" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childConcept" flags="ng" index="2DD5aU" />
       <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
         <reference id="1213093996982" name="concept" index="1M2myG" />
+        <child id="6702802731807532730" name="canBeAncestor" index="9SGkC" />
         <child id="6702802731807737306" name="canBeChild" index="9Vyp8" />
       </concept>
     </language>
@@ -36,13 +62,28 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1172326502327" name="jetbrains.mps.lang.smodel.structure.Concept_IsExactlyOperation" flags="nn" index="3O6GUB">
+        <child id="1206733650006" name="conceptArgument" index="3QVz_e" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
   </registry>
@@ -57,6 +98,82 @@
             <node concept="1mIQ4w" id="vJfcQmmcNB" role="2OqNvi">
               <node concept="chp4Y" id="vJfcQmmcQ7" role="cj9EA">
                 <ref role="cht4Q" to="pkab:vJfcQmm5$y" resolve="IntegerRange" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="4OYzbeqXIYw">
+    <property role="3GE5qa" value="scopeFunction" />
+    <ref role="1M2myG" to="pkab:4OYzbeq$iVd" resolve="SmartAtomicClosureParameterDeclaration" />
+    <node concept="9S07l" id="4OYzbeqXIYx" role="9Vyp8">
+      <node concept="3clFbS" id="4OYzbeqXIYy" role="2VODD2">
+        <node concept="Jncv_" id="4OYzbeqXJOr" role="3cqZAp">
+          <ref role="JncvD" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+          <node concept="3clFbS" id="4OYzbeqXJOt" role="Jncv$">
+            <node concept="Jncv_" id="4OYzbeqXKSY" role="3cqZAp">
+              <ref role="JncvD" to="pkab:2oJmO5M0doP" resolve="ScopeFunctionOperation" />
+              <node concept="2OqwBi" id="4OYzbeqXLAB" role="JncvB">
+                <node concept="Jnkvi" id="4OYzbeqXKTD" role="2Oq$k0">
+                  <ref role="1M0zk5" node="4OYzbeqXJOu" resolve="closure" />
+                </node>
+                <node concept="1mfA1w" id="4OYzbeqXMBu" role="2OqNvi" />
+              </node>
+              <node concept="3clFbS" id="4OYzbeqXKT0" role="Jncv$">
+                <node concept="3cpWs6" id="4OYzbeqXMER" role="3cqZAp">
+                  <node concept="3clFbT" id="4OYzbeqXMFt" role="3cqZAk">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="JncvC" id="4OYzbeqXKT1" role="JncvA">
+                <property role="TrG5h" value="scopeFunctionOperation" />
+                <node concept="2jxLKc" id="4OYzbeqXKT2" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="4OYzbeqXJOu" role="JncvA">
+            <property role="TrG5h" value="closure" />
+            <node concept="2jxLKc" id="4OYzbeqXJOv" role="1tU5fm" />
+          </node>
+          <node concept="nLn13" id="4OYzbeqXKif" role="JncvB" />
+        </node>
+        <node concept="3cpWs6" id="4OYzbeqXMGP" role="3cqZAp">
+          <node concept="3clFbT" id="4OYzbeqXMIp" role="3cqZAk" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="4OYzber0nbi">
+    <property role="3GE5qa" value="scopeFunction" />
+    <ref role="1M2myG" to="pkab:2oJmO5M0doP" resolve="ScopeFunctionOperation" />
+    <node concept="9SQb8" id="4OYzber0nbk" role="9SGkC">
+      <node concept="3clFbS" id="4OYzber0nbl" role="2VODD2">
+        <node concept="3clFbF" id="4OYzber1TvQ" role="3cqZAp">
+          <node concept="22lmx$" id="4OYzber1ULz" role="3clFbG">
+            <node concept="3fqX7Q" id="4OYzber1TvM" role="3uHU7B">
+              <node concept="2OqwBi" id="4OYzber1Tx1" role="3fr31v">
+                <node concept="2DD5aU" id="4OYzber1Tx2" role="2Oq$k0" />
+                <node concept="3O6GUB" id="4OYzber1Tx3" role="2OqNvi">
+                  <node concept="chp4Y" id="4OYzber1Tx4" role="3QVz_e">
+                    <ref role="cht4Q" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3fqX7Q" id="4OYzber7bac" role="3uHU7w">
+              <node concept="2OqwBi" id="4OYzber7bae" role="3fr31v">
+                <node concept="2OqwBi" id="4OYzber7baf" role="2Oq$k0">
+                  <node concept="nLn13" id="4OYzber7bag" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="4OYzber7bah" role="2OqNvi" />
+                </node>
+                <node concept="1mIQ4w" id="4OYzber7bai" role="2OqNvi">
+                  <node concept="chp4Y" id="4OYzber7baj" role="cj9EA">
+                    <ref role="cht4Q" to="pkab:2oJmO5M0doP" resolve="ScopeFunctionOperation" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.editor.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.editor.mps
@@ -10,6 +10,7 @@
     <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
     <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -33,6 +34,9 @@
       <concept id="1177335944525" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_SubstituteString" flags="in" index="uGdhv" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
+        <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
       <concept id="615427434521884870" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Subconcepts" flags="ng" index="2VfDsV" />
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
@@ -411,6 +415,28 @@
     <property role="3GE5qa" value="integerRange" />
     <ref role="aqKnT" to="pkab:vJfcQmma$O" resolve="IntegerRangeConstantBound" />
     <node concept="22hDWj" id="6vHuLLnCVGp" role="22hAXT" />
+  </node>
+  <node concept="24kQdi" id="2oJmO5M1wK0">
+    <property role="3GE5qa" value="scopeFunction" />
+    <ref role="1XX52x" to="pkab:2oJmO5M0doP" resolve="ScopeFunctionOperation" />
+    <node concept="3EZMnI" id="2oJmO5M1wK2" role="2wV5jI">
+      <node concept="PMmxH" id="2oJmO5M1wK8" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+        <ref role="1k5W1q" to="tpen:hFITtyA" resolve="CompactKeyWord" />
+      </node>
+      <node concept="3F0ifn" id="2oJmO5M1wKa" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <ref role="1k5W1q" to="tpen:hY9fg1G" resolve="LeftParenAfterName" />
+      </node>
+      <node concept="3F1sOY" id="2oJmO5M1wKf" role="3EZMnx">
+        <ref role="1NtTu8" to="pkab:2oJmO5M0doR" resolve="closure" />
+      </node>
+      <node concept="3F0ifn" id="2oJmO5M1wKi" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <ref role="1k5W1q" to="tpen:hFCSUmN" resolve="RightParen" />
+      </node>
+      <node concept="2iRfu4" id="2oJmO5M1wK5" role="2iSdaV" />
+    </node>
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
@@ -14,6 +14,7 @@
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
+        <property id="4628067390765956802" name="abstract" index="R5$K7" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
         <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
         <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
@@ -128,11 +129,11 @@
     <property role="3GE5qa" value="groupByOperation" />
     <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
   </node>
-  <node concept="1TIwiD" id="6RqC_fThQjL">
-    <property role="EcuMT" value="7915817776605258993" />
-    <property role="TrG5h" value="SelectWithIndexOperation" />
-    <property role="34LRSv" value="selectIdx" />
-    <property role="R4oN_" value="transform each element and index" />
+  <node concept="1TIwiD" id="7Ja64GBeeCt">
+    <property role="EcuMT" value="8919968723020343837" />
+    <property role="TrG5h" value="ForEachWithIndexOperation" />
+    <property role="34LRSv" value="forEachIdx" />
+    <property role="R4oN_" value="execute for each element with index" />
     <property role="3GE5qa" value="withIndexOperations" />
     <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
   </node>
@@ -144,13 +145,54 @@
     <property role="3GE5qa" value="withIndexOperations" />
     <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
   </node>
-  <node concept="1TIwiD" id="7Ja64GBeeCt">
-    <property role="EcuMT" value="8919968723020343837" />
-    <property role="TrG5h" value="ForEachWithIndexOperation" />
-    <property role="34LRSv" value="forEachIdx" />
-    <property role="R4oN_" value="execute for each element with index" />
+  <node concept="1TIwiD" id="6RqC_fThQjL">
+    <property role="EcuMT" value="7915817776605258993" />
+    <property role="TrG5h" value="SelectWithIndexOperation" />
+    <property role="34LRSv" value="selectIdx" />
+    <property role="R4oN_" value="transform each element and index" />
     <property role="3GE5qa" value="withIndexOperations" />
     <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+  </node>
+  <node concept="1TIwiD" id="2oJmO5M0doW">
+    <property role="EcuMT" value="2751518233990321724" />
+    <property role="3GE5qa" value="scopeFunction" />
+    <property role="TrG5h" value="LetScopeFunctionOperation" />
+    <property role="34LRSv" value="let" />
+    <property role="R4oN_" value="select anything from any object/instance" />
+    <ref role="1TJDcQ" node="2oJmO5M0doP" resolve="ScopeFunctionOperation" />
+  </node>
+  <node concept="1TIwiD" id="2oJmO5M0doT">
+    <property role="EcuMT" value="2751518233990321721" />
+    <property role="3GE5qa" value="scopeFunction" />
+    <property role="TrG5h" value="ApplyScopeFunctionOperation" />
+    <property role="34LRSv" value="apply" />
+    <property role="R4oN_" value="configure a given object/instance" />
+    <ref role="1TJDcQ" node="2oJmO5M0doP" resolve="ScopeFunctionOperation" />
+  </node>
+  <node concept="1TIwiD" id="2oJmO5M0doP">
+    <property role="EcuMT" value="2751518233990321717" />
+    <property role="R5$K7" value="true" />
+    <property role="TrG5h" value="ScopeFunctionOperation" />
+    <property role="3GE5qa" value="scopeFunction" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="2oJmO5M0doQ" role="PzmwI">
+      <ref role="PrY4T" to="tpee:hqOqG0K" resolve="IOperation" />
+    </node>
+    <node concept="1TJgyj" id="2oJmO5M0doR" role="1TKVEi">
+      <property role="IQ2ns" value="2751518233990321719" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="closure" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="4OYzbeq$iVd">
+    <property role="EcuMT" value="5566040892496752333" />
+    <property role="3GE5qa" value="scopeFunction" />
+    <property role="TrG5h" value="SmartAtomicClosureParameterDeclaration" />
+    <property role="34LRSv" value="~ &lt;name&gt;" />
+    <property role="R4oN_" value="smart closure parameter" />
+    <ref role="1TJDcQ" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
@@ -11,6 +11,7 @@
     <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
     <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" implicit="true" />
     <import index="tpek" ref="r:00000000-0000-4000-0000-011c895902c0(jetbrains.mps.baseLanguage.behavior)" implicit="true" />
+    <import index="tp2c" ref="r:00000000-0000-4000-0000-011c89590338(jetbrains.mps.baseLanguage.closures.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -158,6 +159,7 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
@@ -828,7 +830,7 @@
       <node concept="1ZobV4" id="6RqC_fThTkm" role="3cqZAp">
         <node concept="mw_s8" id="6RqC_fThTlB" role="1ZfhK$">
           <node concept="1Z$b5t" id="6RqC_fThTl_" role="mwGJk">
-            <ref role="1Z$eMM" node="6RqC_fThS0E" resolve="paramType" />
+            <ref role="1Z$eMM" node="6RqC_fThS0E" resolve="seqParamType" />
           </node>
         </node>
         <node concept="mw_s8" id="6RqC_fThTlK" role="1ZfhKB">
@@ -845,7 +847,7 @@
             <ref role="1YBMHb" node="6RqC_fThRO1" resolve="selectWithIndexOperation" />
           </node>
           <node concept="1Z$b5t" id="6RqC_fThS0J" role="37wK5m">
-            <ref role="1Z$eMM" node="6RqC_fThS0E" resolve="paramType" />
+            <ref role="1Z$eMM" node="6RqC_fThS0E" resolve="seqParamType" />
           </node>
           <node concept="2c44tf" id="6RqC_fThS0K" role="37wK5m">
             <node concept="1ajhzC" id="6RqC_fThS0L" role="2c44tc">
@@ -860,7 +862,7 @@
               <node concept="33vP2l" id="6RqC_fThS0P" role="1ajl9A">
                 <node concept="2c44te" id="6RqC_fThS0Q" role="lGtFl">
                   <node concept="1Z$b5t" id="6RqC_fThS0R" role="2c44t1">
-                    <ref role="1Z$eMM" node="6RqC_fThS0F" resolve="keyType" />
+                    <ref role="1Z$eMM" node="6RqC_fThS0F" resolve="returnType" />
                   </node>
                 </node>
               </node>
@@ -896,66 +898,6 @@
       <ref role="1YaFvo" to="pkab:6RqC_fThQjL" resolve="SelectWithIndexOperation" />
     </node>
   </node>
-  <node concept="1YbPZF" id="7Ja64GBdQEI">
-    <property role="TrG5h" value="typeof_WhereWithIndexOperation" />
-    <property role="3GE5qa" value="withIndexOperations" />
-    <node concept="3clFbS" id="7Ja64GBdQEJ" role="18ibNy">
-      <node concept="1ZxtTE" id="hwyZbXq" role="3cqZAp">
-        <property role="TrG5h" value="paramType" />
-      </node>
-      <node concept="3clFbF" id="34jUqC_VPJv" role="3cqZAp">
-        <node concept="2YIFZM" id="34jUqC_VR5x" role="3clFbG">
-          <ref role="37wK5l" to="tp2v:4Iwp2tSBzXf" resolve="inferInternalOperation" />
-          <ref role="1Pybhc" to="tp2v:4Iwp2tSBvWa" resolve="OperationInference" />
-          <node concept="1YBJjd" id="34jUqC_VR5y" role="37wK5m">
-            <ref role="1YBMHb" node="7Ja64GBdQEL" resolve="wo" />
-          </node>
-          <node concept="1Z$b5t" id="34jUqC_VR5z" role="37wK5m">
-            <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
-          </node>
-          <node concept="2c44tf" id="7Ja64GBdQER" role="37wK5m">
-            <node concept="1ajhzC" id="7Ja64GBdQES" role="2c44tc">
-              <node concept="33vP2l" id="7Ja64GBdQET" role="1ajw0F">
-                <node concept="2c44te" id="7Ja64GBdQEU" role="lGtFl">
-                  <node concept="1Z$b5t" id="7Ja64GBdQEV" role="2c44t1">
-                    <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
-                  </node>
-                </node>
-              </node>
-              <node concept="10Oyi0" id="7Ja64GBdR9R" role="1ajw0F" />
-              <node concept="10P_77" id="34jUqC_VR5D" role="1ajl9A" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1Z5TYs" id="hwyZxSY" role="3cqZAp">
-        <node concept="mw_s8" id="hwyZRij" role="1ZfhKB">
-          <node concept="2c44tf" id="hwyZRik" role="mwGJk">
-            <node concept="A3Dl8" id="hwyZRB2" role="2c44tc">
-              <node concept="33vP2l" id="hwyZRB3" role="A3Ik2">
-                <node concept="2c44te" id="hwyZRRP" role="lGtFl">
-                  <node concept="1Z$b5t" id="hwyZS6_" role="2c44t1">
-                    <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="mw_s8" id="hwyZxT1" role="1ZfhK$">
-          <node concept="1Z2H0r" id="hwyZwPr" role="mwGJk">
-            <node concept="1YBJjd" id="hwyZxjd" role="1Z2MuG">
-              <ref role="1YBMHb" node="7Ja64GBdQEL" resolve="wo" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1YaCAy" id="7Ja64GBdQEL" role="1YuTPh">
-      <property role="TrG5h" value="whereIdxOp" />
-      <ref role="1YaFvo" to="pkab:7Ja64GBdQxd" resolve="WhereWithIndexOperation" />
-    </node>
-  </node>
   <node concept="1YbPZF" id="7Ja64GBegld">
     <property role="TrG5h" value="typeof_ForEachWithIndexOperation" />
     <property role="3GE5qa" value="withIndexOperations" />
@@ -969,7 +911,7 @@
             <property role="3wDh2S" value="false" />
             <node concept="mw_s8" id="3qDC_E6zv71" role="1ZfhKB">
               <node concept="2X3wrD" id="3qDC_E6zv6V" role="mwGJk">
-                <ref role="2X3Bk0" node="3qDC_E6ztIR" resolve="O" />
+                <ref role="2X3Bk0" node="3qDC_E6ztIR" resolve="operandType" />
               </node>
             </node>
             <node concept="mw_s8" id="hPGtiwH" role="1ZfhK$">
@@ -1006,7 +948,7 @@
               <node concept="1Z2H0r" id="hPGmR$c" role="mwGJk">
                 <node concept="2OqwBi" id="hPGmS7e" role="1Z2MuG">
                   <node concept="1YBJjd" id="hPGmRZV" role="2Oq$k0">
-                    <ref role="1YBMHb" node="7Ja64GBeglg" resolve="vo" />
+                    <ref role="1YBMHb" node="7Ja64GBeglg" resolve="forEachIdxOp" />
                   </node>
                   <node concept="3TrEf2" id="7Ja64GBegM7" role="2OqNvi">
                     <ref role="3Tt5mk" to="tp2q:hy3t8hi" resolve="closure" />
@@ -1023,7 +965,7 @@
         <node concept="1Z2H0r" id="3qDC_E6zWkg" role="nvjzm">
           <node concept="2OqwBi" id="3qDC_E6zu0P" role="1Z2MuG">
             <node concept="1YBJjd" id="3qDC_E6ztQz" role="2Oq$k0">
-              <ref role="1YBMHb" node="7Ja64GBeglg" resolve="vo" />
+              <ref role="1YBMHb" node="7Ja64GBeglg" resolve="forEachIdxOp" />
             </node>
             <node concept="2qgKlT" id="3qDC_E6zuz8" role="2OqNvi">
               <ref role="37wK5l" to="tpek:hEwIP$m" resolve="getOperand" />
@@ -1035,7 +977,7 @@
         <node concept="mw_s8" id="hz1N55C" role="1ZfhK$">
           <node concept="1Z2H0r" id="hz1N55D" role="mwGJk">
             <node concept="1YBJjd" id="hz1N5qN" role="1Z2MuG">
-              <ref role="1YBMHb" node="7Ja64GBeglg" resolve="vo" />
+              <ref role="1YBMHb" node="7Ja64GBeglg" resolve="forEachIdxOp" />
             </node>
           </node>
         </node>
@@ -1049,6 +991,373 @@
     <node concept="1YaCAy" id="7Ja64GBeglg" role="1YuTPh">
       <property role="TrG5h" value="forEachIdxOp" />
       <ref role="1YaFvo" to="pkab:7Ja64GBeeCt" resolve="ForEachWithIndexOperation" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="7Ja64GBdQEI">
+    <property role="TrG5h" value="typeof_WhereWithIndexOperation" />
+    <property role="3GE5qa" value="withIndexOperations" />
+    <node concept="3clFbS" id="7Ja64GBdQEJ" role="18ibNy">
+      <node concept="1ZxtTE" id="hwyZbXq" role="3cqZAp">
+        <property role="TrG5h" value="paramType" />
+      </node>
+      <node concept="3clFbF" id="34jUqC_VPJv" role="3cqZAp">
+        <node concept="2YIFZM" id="34jUqC_VR5x" role="3clFbG">
+          <ref role="37wK5l" to="tp2v:4Iwp2tSBzXf" resolve="inferInternalOperation" />
+          <ref role="1Pybhc" to="tp2v:4Iwp2tSBvWa" resolve="OperationInference" />
+          <node concept="1YBJjd" id="34jUqC_VR5y" role="37wK5m">
+            <ref role="1YBMHb" node="7Ja64GBdQEL" resolve="whereIdxOp" />
+          </node>
+          <node concept="1Z$b5t" id="34jUqC_VR5z" role="37wK5m">
+            <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
+          </node>
+          <node concept="2c44tf" id="7Ja64GBdQER" role="37wK5m">
+            <node concept="1ajhzC" id="7Ja64GBdQES" role="2c44tc">
+              <node concept="33vP2l" id="7Ja64GBdQET" role="1ajw0F">
+                <node concept="2c44te" id="7Ja64GBdQEU" role="lGtFl">
+                  <node concept="1Z$b5t" id="7Ja64GBdQEV" role="2c44t1">
+                    <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="10Oyi0" id="7Ja64GBdR9R" role="1ajw0F" />
+              <node concept="10P_77" id="34jUqC_VR5D" role="1ajl9A" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1Z5TYs" id="hwyZxSY" role="3cqZAp">
+        <node concept="mw_s8" id="hwyZRij" role="1ZfhKB">
+          <node concept="2c44tf" id="hwyZRik" role="mwGJk">
+            <node concept="A3Dl8" id="hwyZRB2" role="2c44tc">
+              <node concept="33vP2l" id="hwyZRB3" role="A3Ik2">
+                <node concept="2c44te" id="hwyZRRP" role="lGtFl">
+                  <node concept="1Z$b5t" id="hwyZS6_" role="2c44t1">
+                    <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hwyZxT1" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hwyZwPr" role="mwGJk">
+            <node concept="1YBJjd" id="hwyZxjd" role="1Z2MuG">
+              <ref role="1YBMHb" node="7Ja64GBdQEL" resolve="whereIdxOp" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7Ja64GBdQEL" role="1YuTPh">
+      <property role="TrG5h" value="whereIdxOp" />
+      <ref role="1YaFvo" to="pkab:7Ja64GBdQxd" resolve="WhereWithIndexOperation" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="2oJmO5M4B3W">
+    <property role="TrG5h" value="typeof_LetScopeFunctionOperation" />
+    <property role="3GE5qa" value="scopeFunction" />
+    <node concept="3clFbS" id="2oJmO5M4B3X" role="18ibNy">
+      <node concept="1ZxtTE" id="2oJmO5M4BiO" role="3cqZAp">
+        <property role="TrG5h" value="operandType" />
+      </node>
+      <node concept="1ZxtTE" id="2oJmO5M4Bty" role="3cqZAp">
+        <property role="TrG5h" value="resultType" />
+      </node>
+      <node concept="1ZobV4" id="2oJmO5M4BL7" role="3cqZAp">
+        <node concept="mw_s8" id="2oJmO5M4BL8" role="1ZfhK$">
+          <node concept="1Z2H0r" id="2oJmO5M4BL9" role="mwGJk">
+            <node concept="2OqwBi" id="2oJmO5M4BLa" role="1Z2MuG">
+              <node concept="1YBJjd" id="2oJmO5M4BLb" role="2Oq$k0">
+                <ref role="1YBMHb" node="2oJmO5M4B3Z" resolve="letScopeFunctionOperation" />
+              </node>
+              <node concept="3TrEf2" id="2oJmO5M4BLc" role="2OqNvi">
+                <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="2oJmO5M4BLd" role="1ZfhKB">
+          <node concept="2c44tf" id="2oJmO5M4BLe" role="mwGJk">
+            <node concept="1ajhzC" id="2oJmO5M4BLf" role="2c44tc">
+              <node concept="33vP2l" id="2oJmO5M4BLg" role="1ajw0F">
+                <node concept="2c44te" id="2oJmO5M4BLh" role="lGtFl">
+                  <node concept="1Z$b5t" id="2oJmO5M4BLi" role="2c44t1">
+                    <ref role="1Z$eMM" node="2oJmO5M4BiO" resolve="operandType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="33vP2l" id="2oJmO5M4BLj" role="1ajl9A">
+                <node concept="2c44te" id="2oJmO5M4BLk" role="lGtFl">
+                  <node concept="1Z$b5t" id="2oJmO5M4BLl" role="2c44t1">
+                    <ref role="1Z$eMM" node="2oJmO5M4Bty" resolve="resultType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1Z5TYs" id="2oJmO5M4CwA" role="3cqZAp">
+        <node concept="mw_s8" id="2oJmO5M4CwK" role="1ZfhKB">
+          <node concept="1Z$b5t" id="2oJmO5M4CwI" role="mwGJk">
+            <ref role="1Z$eMM" node="2oJmO5M4Bty" resolve="resultType" />
+          </node>
+        </node>
+        <node concept="mw_s8" id="2oJmO5M4CwD" role="1ZfhK$">
+          <node concept="1Z2H0r" id="2oJmO5M4C8c" role="mwGJk">
+            <node concept="1YBJjd" id="2oJmO5M4Ca5" role="1Z2MuG">
+              <ref role="1YBMHb" node="2oJmO5M4B3Z" resolve="letScopeFunctionOperation" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="2oJmO5M4B3Z" role="1YuTPh">
+      <property role="TrG5h" value="letScopeFunctionOperation" />
+      <ref role="1YaFvo" to="pkab:2oJmO5M0doW" resolve="LetScopeFunctionOperation" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="2oJmO5M48Z6">
+    <property role="TrG5h" value="typeof_ApplyScopeFunctionOperation" />
+    <property role="3GE5qa" value="scopeFunction" />
+    <node concept="3clFbS" id="2oJmO5M48Z7" role="18ibNy">
+      <node concept="1ZxtTE" id="2oJmO5M49dR" role="3cqZAp">
+        <property role="TrG5h" value="operandType" />
+      </node>
+      <node concept="1Z5TYs" id="2oJmO5M4aAQ" role="3cqZAp">
+        <node concept="mw_s8" id="2oJmO5M4aAS" role="1ZfhK$">
+          <node concept="1Z2H0r" id="2oJmO5M4aAT" role="mwGJk">
+            <node concept="2OqwBi" id="2oJmO5M4aAU" role="1Z2MuG">
+              <node concept="1PxgMI" id="2oJmO5M4aAV" role="2Oq$k0">
+                <node concept="chp4Y" id="2oJmO5M4aAW" role="3oSUPX">
+                  <ref role="cht4Q" to="tpee:hqOqwz4" resolve="DotExpression" />
+                </node>
+                <node concept="2OqwBi" id="2oJmO5M4aAX" role="1m5AlR">
+                  <node concept="1YBJjd" id="2oJmO5M4aAY" role="2Oq$k0">
+                    <ref role="1YBMHb" node="2oJmO5M48Z9" resolve="applyScopeFunctionOperation" />
+                  </node>
+                  <node concept="1mfA1w" id="2oJmO5M4aAZ" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="3TrEf2" id="2oJmO5M4aB0" role="2OqNvi">
+                <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="2oJmO5M4aBH" role="1ZfhKB">
+          <node concept="1Z$b5t" id="2oJmO5M4aBF" role="mwGJk">
+            <ref role="1Z$eMM" node="2oJmO5M49dR" resolve="operandType" />
+          </node>
+        </node>
+      </node>
+      <node concept="1Z5TYs" id="2oJmO5M4b93" role="3cqZAp">
+        <node concept="mw_s8" id="2oJmO5M4b9d" role="1ZfhKB">
+          <node concept="1Z$b5t" id="2oJmO5M4b9b" role="mwGJk">
+            <ref role="1Z$eMM" node="2oJmO5M49dR" resolve="operandType" />
+          </node>
+        </node>
+        <node concept="mw_s8" id="2oJmO5M4b96" role="1ZfhK$">
+          <node concept="1Z2H0r" id="2oJmO5M4aMj" role="mwGJk">
+            <node concept="1YBJjd" id="2oJmO5M4aOc" role="1Z2MuG">
+              <ref role="1YBMHb" node="2oJmO5M48Z9" resolve="applyScopeFunctionOperation" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="2oJmO5M48Z9" role="1YuTPh">
+      <property role="TrG5h" value="applyScopeFunctionOperation" />
+      <ref role="1YaFvo" to="pkab:2oJmO5M0doT" resolve="ApplyScopeFunctionOperation" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="2oJmO5M2lEY">
+    <property role="TrG5h" value="typeof_ScopeFunctionOperation" />
+    <property role="3GE5qa" value="scopeFunction" />
+    <node concept="3clFbS" id="2oJmO5M2lEZ" role="18ibNy">
+      <node concept="1ZxtTE" id="2oJmO5M2m2j" role="3cqZAp">
+        <property role="TrG5h" value="operandType" />
+      </node>
+      <node concept="1ZxtTE" id="2oJmO5M2mh1" role="3cqZAp">
+        <property role="TrG5h" value="resultType" />
+      </node>
+      <node concept="1Z5TYs" id="2oJmO5M2o91" role="3cqZAp">
+        <node concept="mw_s8" id="2oJmO5M2o93" role="1ZfhK$">
+          <node concept="1Z2H0r" id="2oJmO5M2o94" role="mwGJk">
+            <node concept="2OqwBi" id="2oJmO5M2o95" role="1Z2MuG">
+              <node concept="1PxgMI" id="2oJmO5M2o96" role="2Oq$k0">
+                <node concept="chp4Y" id="2oJmO5M2o97" role="3oSUPX">
+                  <ref role="cht4Q" to="tpee:hqOqwz4" resolve="DotExpression" />
+                </node>
+                <node concept="2OqwBi" id="2oJmO5M2o98" role="1m5AlR">
+                  <node concept="1YBJjd" id="2oJmO5M2o99" role="2Oq$k0">
+                    <ref role="1YBMHb" node="2oJmO5M2lF1" resolve="scopeFunctionOperation" />
+                  </node>
+                  <node concept="1mfA1w" id="2oJmO5M2o9a" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="3TrEf2" id="2oJmO5M2o9b" role="2OqNvi">
+                <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="2oJmO5M2o9c" role="1ZfhKB">
+          <node concept="1Z$b5t" id="2oJmO5M2o9d" role="mwGJk">
+            <ref role="1Z$eMM" node="2oJmO5M2m2j" resolve="operandType" />
+          </node>
+        </node>
+      </node>
+      <node concept="1ZobV4" id="2oJmO5M2oq0" role="3cqZAp">
+        <node concept="mw_s8" id="2oJmO5M2oq7" role="1ZfhK$">
+          <node concept="1Z2H0r" id="2oJmO5M2oq3" role="mwGJk">
+            <node concept="2OqwBi" id="2oJmO5M2ozm" role="1Z2MuG">
+              <node concept="1YBJjd" id="2oJmO5M2oql" role="2Oq$k0">
+                <ref role="1YBMHb" node="2oJmO5M2lF1" resolve="scopeFunctionOperation" />
+              </node>
+              <node concept="3TrEf2" id="2oJmO5M2oPs" role="2OqNvi">
+                <ref role="3Tt5mk" to="pkab:2oJmO5M0doR" resolve="closure" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="2oJmO5M2oSn" role="1ZfhKB">
+          <node concept="2c44tf" id="2oJmO5M2oSj" role="mwGJk">
+            <node concept="1ajhzC" id="2oJmO5M2pBm" role="2c44tc">
+              <node concept="33vP2l" id="2oJmO5M2pBG" role="1ajw0F">
+                <node concept="2c44te" id="2oJmO5M2pC2" role="lGtFl">
+                  <node concept="1Z$b5t" id="2oJmO5M2pCa" role="2c44t1">
+                    <ref role="1Z$eMM" node="2oJmO5M2m2j" resolve="operandType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="33vP2l" id="2oJmO5M2pBn" role="1ajl9A">
+                <node concept="2c44te" id="2oJmO5M2pCh" role="lGtFl">
+                  <node concept="1Z$b5t" id="2oJmO5M2pCp" role="2c44t1">
+                    <ref role="1Z$eMM" node="2oJmO5M2mh1" resolve="resultType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="2oJmO5M2lF1" role="1YuTPh">
+      <property role="TrG5h" value="scopeFunctionOperation" />
+      <ref role="1YaFvo" to="pkab:2oJmO5M0doP" resolve="ScopeFunctionOperation" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="4OYzbeq$kbQ">
+    <property role="TrG5h" value="typeof_SmartAtomicClosureParameterDeclaration" />
+    <property role="3GE5qa" value="scopeFunction" />
+    <node concept="3clFbS" id="4OYzbeq$kbR" role="18ibNy">
+      <node concept="3clFbJ" id="4OYzbeq$kFd" role="3cqZAp">
+        <node concept="3clFbS" id="4OYzbeq$kFf" role="3clFbx">
+          <node concept="1ZxtTE" id="2l26Z_sw2Vl" role="3cqZAp">
+            <property role="TrG5h" value="opType" />
+          </node>
+          <node concept="1Z5TYs" id="2l26Z_sw2VH" role="3cqZAp">
+            <node concept="mw_s8" id="2l26Z_sw2VK" role="1ZfhK$">
+              <node concept="1Z$b5t" id="2l26Z_sw2Vo" role="mwGJk">
+                <ref role="1Z$eMM" node="2l26Z_sw2Vl" resolve="opType" />
+              </node>
+            </node>
+            <node concept="mw_s8" id="2l26Z_sw2VM" role="1ZfhKB">
+              <node concept="1Z2H0r" id="2l26Z_sw2VN" role="mwGJk">
+                <node concept="2OqwBi" id="2l26Z_sw2VO" role="1Z2MuG">
+                  <node concept="1PxgMI" id="2l26Z_sw2VP" role="2Oq$k0">
+                    <node concept="2OqwBi" id="2l26Z_sw2VQ" role="1m5AlR">
+                      <node concept="2OqwBi" id="2l26Z_sw2VR" role="2Oq$k0">
+                        <node concept="1YBJjd" id="2l26Z_sw2VS" role="2Oq$k0">
+                          <ref role="1YBMHb" node="4OYzbeq$kbT" resolve="sacpd" />
+                        </node>
+                        <node concept="1mfA1w" id="2l26Z_sw2VT" role="2OqNvi" />
+                      </node>
+                      <node concept="1mfA1w" id="2l26Z_sw2VU" role="2OqNvi" />
+                    </node>
+                    <node concept="chp4Y" id="714IaVdGYDV" role="3oSUPX">
+                      <ref role="cht4Q" to="pkab:2oJmO5M0doP" resolve="ScopeFunctionOperation" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="2l26Z_sw2VV" role="2OqNvi">
+                    <ref role="37wK5l" to="tpek:hEwIP$m" resolve="getOperand" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="nvevp" id="2l26Z_sw2VX" role="3cqZAp">
+            <node concept="3clFbS" id="2l26Z_sw2VY" role="nvhr_">
+              <node concept="1Z5TYs" id="6DFN5BsVqJ1" role="3cqZAp">
+                <node concept="mw_s8" id="6DFN5BsVqJ2" role="1ZfhKB">
+                  <node concept="1Z$b5t" id="6DFN5BsVqJ3" role="mwGJk">
+                    <ref role="1Z$eMM" node="2l26Z_sw2Vl" resolve="opType" />
+                  </node>
+                </node>
+                <node concept="mw_s8" id="6DFN5BsVqJ4" role="1ZfhK$">
+                  <node concept="1Z2H0r" id="6DFN5BsVqJ5" role="mwGJk">
+                    <node concept="1YBJjd" id="6DFN5BsVqJ6" role="1Z2MuG">
+                      <ref role="1YBMHb" node="4OYzbeq$kbT" resolve="sacpd" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Z$b5t" id="2l26Z_sw2W2" role="nvjzm">
+              <ref role="1Z$eMM" node="2l26Z_sw2Vl" resolve="opType" />
+            </node>
+            <node concept="2X1qdy" id="2l26Z_sw2W0" role="2X0Ygz">
+              <property role="TrG5h" value="opTypeConcrete" />
+              <node concept="2jxLKc" id="2l26Z_sw2W1" role="1tU5fm" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Wc70l" id="hTOyrmC" role="3clFbw">
+          <node concept="2OqwBi" id="hTOyt8S" role="3uHU7w">
+            <node concept="2OqwBi" id="hTOys4S" role="2Oq$k0">
+              <node concept="2OqwBi" id="hTOyrDE" role="2Oq$k0">
+                <node concept="1YBJjd" id="hTOyrAw" role="2Oq$k0">
+                  <ref role="1YBMHb" node="4OYzbeq$kbT" resolve="sacpd" />
+                </node>
+                <node concept="1mfA1w" id="hTOyrZu" role="2OqNvi" />
+              </node>
+              <node concept="1mfA1w" id="hTOyskn" role="2OqNvi" />
+            </node>
+            <node concept="1mIQ4w" id="hTOytGB" role="2OqNvi">
+              <node concept="chp4Y" id="hTOyEtR" role="cj9EA">
+                <ref role="cht4Q" to="pkab:2oJmO5M0doP" resolve="ScopeFunctionOperation" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="hTOypeF" role="3uHU7B">
+            <node concept="2OqwBi" id="hTOyoSO" role="2Oq$k0">
+              <node concept="1YBJjd" id="hTOyoPy" role="2Oq$k0">
+                <ref role="1YBMHb" node="4OYzbeq$kbT" resolve="sacpd" />
+              </node>
+              <node concept="1mfA1w" id="hTOyp8H" role="2OqNvi" />
+            </node>
+            <node concept="1mIQ4w" id="hTOyq9Z" role="2OqNvi">
+              <node concept="chp4Y" id="hTOyqZj" role="cj9EA">
+                <ref role="cht4Q" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="4OYzbeq$kbT" role="1YuTPh">
+      <property role="TrG5h" value="sacpd" />
+      <ref role="1YaFvo" to="pkab:4OYzbeq$iVd" resolve="SmartAtomicClosureParameterDeclaration" />
+    </node>
+    <node concept="bXqS6" id="4OYzbeq$kbX" role="ujSXK">
+      <node concept="3clFbS" id="4OYzbeq$kbY" role="2VODD2">
+        <node concept="3clFbF" id="4OYzbeq$kpu" role="3cqZAp">
+          <node concept="3clFbT" id="4OYzbeq$kpt" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/solutions/de.itemis.mps.baseLanguageExtensions.test/de.itemis.mps.baseLanguageExtensions.test.msd
+++ b/code/solutions/de.itemis.mps.baseLanguageExtensions.test/de.itemis.mps.baseLanguageExtensions.test.msd
@@ -25,6 +25,7 @@
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>

--- a/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.scopeFunction@tests.mps
+++ b/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.scopeFunction@tests.mps
@@ -1,0 +1,871 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:5a7ae83c-2b1a-41f2-9470-4c8a2c3100ea(de.itemis.mps.baseLanguageExtensions.test.scopeFunction@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+  </languages>
+  <imports>
+    <import index="96gm" ref="r:2eaed950-3bc1-47cd-9b02-e917ff994d7c(de.itemis.mps.baseLanguageExtensions.runtime)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171931690126" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethod" flags="ig" index="3s$Bmu">
+        <property id="1171931690128" name="methodName" index="3s$Bm0" />
+      </concept>
+      <concept id="1171931851043" name="jetbrains.mps.baseLanguage.unitTest.structure.BTestCase" flags="ig" index="3s_ewN">
+        <property id="1171931851045" name="testCaseName" index="3s_ewP" />
+        <child id="1171931851044" name="testMethodList" index="3s_ewO" />
+      </concept>
+      <concept id="1171931858461" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethodList" flags="ng" index="3s_gsd">
+        <child id="1171931858462" name="testMethod" index="3s_gse" />
+      </concept>
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="3s_ewN" id="2oJmO5LY5Fb">
+    <property role="3s_ewP" value="ApplyFunction" />
+    <node concept="3Tm1VV" id="2oJmO5LY5Fc" role="1B3o_S" />
+    <node concept="3s_gsd" id="2oJmO5LY5Fd" role="3s_ewO">
+      <node concept="3s$Bmu" id="2oJmO5LY5N2" role="3s_gse">
+        <property role="3s$Bm0" value="chainStringBuildingWithApply" />
+        <node concept="3cqZAl" id="2oJmO5LY5N3" role="3clF45" />
+        <node concept="3Tm1VV" id="2oJmO5LY5N4" role="1B3o_S" />
+        <node concept="3clFbS" id="2oJmO5LY5N5" role="3clF47">
+          <node concept="3SKdUt" id="6vHuLLnDlS_" role="3cqZAp">
+            <node concept="1PaTwC" id="6vHuLLnDlSA" role="1aUNEU">
+              <node concept="3oM_SD" id="2oJmO5LZ4Xw" role="1PaTwD">
+                <property role="3oM_SC" value="this" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4Xx" role="1PaTwD">
+                <property role="3oM_SC" value="would" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4Xy" role="1PaTwD">
+                <property role="3oM_SC" value="work" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4Xz" role="1PaTwD">
+                <property role="3oM_SC" value="just" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4X$" role="1PaTwD">
+                <property role="3oM_SC" value="as" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4X_" role="1PaTwD">
+                <property role="3oM_SC" value="well" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4XA" role="1PaTwD">
+                <property role="3oM_SC" value="without" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4XB" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4XC" role="1PaTwD">
+                <property role="3oM_SC" value="apply," />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4XD" role="1PaTwD">
+                <property role="3oM_SC" value="but" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4XE" role="1PaTwD">
+                <property role="3oM_SC" value="it" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4XF" role="1PaTwD">
+                <property role="3oM_SC" value="highlights" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4XG" role="1PaTwD">
+                <property role="3oM_SC" value="that" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4XH" role="1PaTwD">
+                <property role="3oM_SC" value="this" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4XI" role="1PaTwD">
+                <property role="3oM_SC" value="preserves" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4XJ" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4XK" role="1PaTwD">
+                <property role="3oM_SC" value="typing" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ4XL" role="1PaTwD">
+                <property role="3oM_SC" value="aspect" />
+              </node>
+            </node>
+          </node>
+          <node concept="3SKdUt" id="2oJmO5LZnho" role="3cqZAp">
+            <node concept="1PaTwC" id="2oJmO5LZnhp" role="1aUNEU">
+              <node concept="3oM_SD" id="2oJmO5LZnyt" role="1PaTwD">
+                <property role="3oM_SC" value="with" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyr" role="1PaTwD">
+                <property role="3oM_SC" value="apply," />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyu" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyv" role="1PaTwD">
+                <property role="3oM_SC" value="original" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyw" role="1PaTwD">
+                <property role="3oM_SC" value="Builder" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyx" role="1PaTwD">
+                <property role="3oM_SC" value="is" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyy" role="1PaTwD">
+                <property role="3oM_SC" value="returned," />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyz" role="1PaTwD">
+                <property role="3oM_SC" value="but" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZny$" role="1PaTwD">
+                <property role="3oM_SC" value="given" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZny_" role="1PaTwD">
+                <property role="3oM_SC" value="that" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyA" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyB" role="1PaTwD">
+                <property role="3oM_SC" value="append" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyC" role="1PaTwD">
+                <property role="3oM_SC" value="methods" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyD" role="1PaTwD">
+                <property role="3oM_SC" value="return" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyE" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyF" role="1PaTwD">
+                <property role="3oM_SC" value="original" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyG" role="1PaTwD">
+                <property role="3oM_SC" value="builder" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyH" role="1PaTwD">
+                <property role="3oM_SC" value="as" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyI" role="1PaTwD">
+                <property role="3oM_SC" value="well," />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyJ" role="1PaTwD">
+                <property role="3oM_SC" value="this" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyK" role="1PaTwD">
+                <property role="3oM_SC" value="behaves" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyL" role="1PaTwD">
+                <property role="3oM_SC" value="exactly" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyM" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyN" role="1PaTwD">
+                <property role="3oM_SC" value="same" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="2oJmO5LY9$v" role="3cqZAp">
+            <node concept="3cpWsn" id="2oJmO5LY9$w" role="3cpWs9">
+              <property role="TrG5h" value="actual" />
+              <node concept="3uibUv" id="2oJmO5LY9xT" role="1tU5fm">
+                <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+              </node>
+              <node concept="2OqwBi" id="2oJmO5LY9$x" role="33vP2m">
+                <node concept="2YIFZM" id="2oJmO5LY9$y" role="2Oq$k0">
+                  <ref role="37wK5l" to="96gm:2oJmO5LUek_" resolve="apply" />
+                  <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+                  <node concept="2YIFZM" id="2oJmO5LZ6v4" role="37wK5m">
+                    <ref role="37wK5l" to="96gm:2oJmO5LUek_" resolve="apply" />
+                    <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+                    <node concept="2YIFZM" id="2oJmO5LZ6v5" role="37wK5m">
+                      <ref role="37wK5l" to="96gm:2oJmO5LUek_" resolve="apply" />
+                      <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+                      <node concept="2YIFZM" id="2oJmO5LZ6v6" role="37wK5m">
+                        <ref role="37wK5l" to="96gm:2oJmO5LUek_" resolve="apply" />
+                        <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+                        <node concept="2ShNRf" id="2oJmO5LZ6v7" role="37wK5m">
+                          <node concept="1pGfFk" id="2oJmO5LZ6v8" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+                          </node>
+                        </node>
+                        <node concept="1bVj0M" id="2oJmO5LZ6v9" role="37wK5m">
+                          <node concept="3clFbS" id="2oJmO5LZ6va" role="1bW5cS">
+                            <node concept="3clFbF" id="2oJmO5LZ6vb" role="3cqZAp">
+                              <node concept="2OqwBi" id="2oJmO5LZ6vc" role="3clFbG">
+                                <node concept="37vLTw" id="2oJmO5LZ6vd" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="2oJmO5LZ6vg" resolve="builder" />
+                                </node>
+                                <node concept="liA8E" id="2oJmO5LZ6ve" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                                  <node concept="Xl_RD" id="2oJmO5LZ6vf" role="37wK5m">
+                                    <property role="Xl_RC" value="Hello" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="37vLTG" id="2oJmO5LZ6vg" role="1bW2Oz">
+                            <property role="TrG5h" value="builder" />
+                            <node concept="3uibUv" id="2oJmO5LZ6vh" role="1tU5fm">
+                              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1bVj0M" id="2oJmO5LZ6vi" role="37wK5m">
+                        <node concept="3clFbS" id="2oJmO5LZ6vj" role="1bW5cS">
+                          <node concept="3clFbF" id="2oJmO5LZ6vk" role="3cqZAp">
+                            <node concept="2OqwBi" id="2oJmO5LZ6vl" role="3clFbG">
+                              <node concept="37vLTw" id="2oJmO5LZ6vm" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2oJmO5LZ6vp" resolve="builder" />
+                              </node>
+                              <node concept="liA8E" id="2oJmO5LZ6vn" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                                <node concept="Xl_RD" id="2oJmO5LZ6vo" role="37wK5m">
+                                  <property role="Xl_RC" value=", " />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="37vLTG" id="2oJmO5LZ6vp" role="1bW2Oz">
+                          <property role="TrG5h" value="builder" />
+                          <node concept="3uibUv" id="2oJmO5LZ6vq" role="1tU5fm">
+                            <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1bVj0M" id="2oJmO5LZ6vr" role="37wK5m">
+                      <node concept="3clFbS" id="2oJmO5LZ6vs" role="1bW5cS">
+                        <node concept="3clFbF" id="2oJmO5LZ6vt" role="3cqZAp">
+                          <node concept="2OqwBi" id="2oJmO5LZ6vu" role="3clFbG">
+                            <node concept="37vLTw" id="2oJmO5LZ6vv" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2oJmO5LZ6vy" resolve="builder" />
+                            </node>
+                            <node concept="liA8E" id="2oJmO5LZ6vw" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                              <node concept="Xl_RD" id="2oJmO5LZ6vx" role="37wK5m">
+                                <property role="Xl_RC" value="World" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="37vLTG" id="2oJmO5LZ6vy" role="1bW2Oz">
+                        <property role="TrG5h" value="builder" />
+                        <node concept="3uibUv" id="2oJmO5LZ6vz" role="1tU5fm">
+                          <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1bVj0M" id="2oJmO5LY9$_" role="37wK5m">
+                    <node concept="3clFbS" id="2oJmO5LY9$A" role="1bW5cS">
+                      <node concept="3clFbF" id="2oJmO5LY9$B" role="3cqZAp">
+                        <node concept="2OqwBi" id="2oJmO5LY9$C" role="3clFbG">
+                          <node concept="37vLTw" id="2oJmO5LY9$D" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2oJmO5LY9$G" resolve="builder" />
+                          </node>
+                          <node concept="liA8E" id="2oJmO5LY9$E" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                            <node concept="Xl_RD" id="2oJmO5LY9$F" role="37wK5m">
+                              <property role="Xl_RC" value="!" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="2oJmO5LY9$G" role="1bW2Oz">
+                      <property role="TrG5h" value="builder" />
+                      <node concept="3uibUv" id="2oJmO5LY9$H" role="1tU5fm">
+                        <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="2oJmO5LY9$I" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2oJmO5LY9S2" role="3cqZAp" />
+          <node concept="3vlDli" id="2oJmO5LYa2E" role="3cqZAp">
+            <node concept="Xl_RD" id="2oJmO5LYa7F" role="3tpDZB">
+              <property role="Xl_RC" value="Hello, World!" />
+            </node>
+            <node concept="37vLTw" id="2oJmO5LYaEA" role="3tpDZA">
+              <ref role="3cqZAo" node="2oJmO5LY9$w" resolve="actual" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="2oJmO5LZ9Vk" role="3s_gse">
+        <property role="3s$Bm0" value="chainStringBuildingWithLet" />
+        <node concept="3cqZAl" id="2oJmO5LZ9Vl" role="3clF45" />
+        <node concept="3Tm1VV" id="2oJmO5LZ9Vm" role="1B3o_S" />
+        <node concept="3clFbS" id="2oJmO5LZ9Vn" role="3clF47">
+          <node concept="3SKdUt" id="2oJmO5LZ9Vo" role="3cqZAp">
+            <node concept="1PaTwC" id="2oJmO5LZ9Vp" role="1aUNEU">
+              <node concept="3oM_SD" id="2oJmO5LZ9Vq" role="1PaTwD">
+                <property role="3oM_SC" value="this" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9Vr" role="1PaTwD">
+                <property role="3oM_SC" value="would" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9Vs" role="1PaTwD">
+                <property role="3oM_SC" value="work" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9Vt" role="1PaTwD">
+                <property role="3oM_SC" value="just" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9Vu" role="1PaTwD">
+                <property role="3oM_SC" value="as" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9Vv" role="1PaTwD">
+                <property role="3oM_SC" value="well" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9Vw" role="1PaTwD">
+                <property role="3oM_SC" value="without" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9Vx" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9Vy" role="1PaTwD">
+                <property role="3oM_SC" value="let," />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9Vz" role="1PaTwD">
+                <property role="3oM_SC" value="but" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9V$" role="1PaTwD">
+                <property role="3oM_SC" value="it" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9V_" role="1PaTwD">
+                <property role="3oM_SC" value="highlights" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9VA" role="1PaTwD">
+                <property role="3oM_SC" value="that" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9VB" role="1PaTwD">
+                <property role="3oM_SC" value="this" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9VC" role="1PaTwD">
+                <property role="3oM_SC" value="preserves" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9VD" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9VE" role="1PaTwD">
+                <property role="3oM_SC" value="typing" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZ9VF" role="1PaTwD">
+                <property role="3oM_SC" value="aspect" />
+              </node>
+            </node>
+          </node>
+          <node concept="3SKdUt" id="2oJmO5LZnyO" role="3cqZAp">
+            <node concept="1PaTwC" id="2oJmO5LZnyP" role="1aUNEU">
+              <node concept="3oM_SD" id="2oJmO5LZnyQ" role="1PaTwD">
+                <property role="3oM_SC" value="with" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyR" role="1PaTwD">
+                <property role="3oM_SC" value="let," />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyS" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyT" role="1PaTwD">
+                <property role="3oM_SC" value="returned" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyU" role="1PaTwD">
+                <property role="3oM_SC" value="Builder" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZogl" role="1PaTwD">
+                <property role="3oM_SC" value="from" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZogm" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZogn" role="1PaTwD">
+                <property role="3oM_SC" value="closure" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyV" role="1PaTwD">
+                <property role="3oM_SC" value="is" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyW" role="1PaTwD">
+                <property role="3oM_SC" value="returned," />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyX" role="1PaTwD">
+                <property role="3oM_SC" value="but" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyY" role="1PaTwD">
+                <property role="3oM_SC" value="given" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnyZ" role="1PaTwD">
+                <property role="3oM_SC" value="that" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnz0" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnz1" role="1PaTwD">
+                <property role="3oM_SC" value="append" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnz2" role="1PaTwD">
+                <property role="3oM_SC" value="methods" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnz3" role="1PaTwD">
+                <property role="3oM_SC" value="return" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnz4" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnz5" role="1PaTwD">
+                <property role="3oM_SC" value="original" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnz6" role="1PaTwD">
+                <property role="3oM_SC" value="builder" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnz7" role="1PaTwD">
+                <property role="3oM_SC" value="as" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnz8" role="1PaTwD">
+                <property role="3oM_SC" value="well," />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnz9" role="1PaTwD">
+                <property role="3oM_SC" value="this" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnza" role="1PaTwD">
+                <property role="3oM_SC" value="behaves" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnzb" role="1PaTwD">
+                <property role="3oM_SC" value="exactly" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnzc" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZnzd" role="1PaTwD">
+                <property role="3oM_SC" value="same" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="2oJmO5LZ9VG" role="3cqZAp">
+            <node concept="3cpWsn" id="2oJmO5LZ9VH" role="3cpWs9">
+              <property role="TrG5h" value="actual" />
+              <node concept="3uibUv" id="2oJmO5LZ9VI" role="1tU5fm">
+                <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+              </node>
+              <node concept="2OqwBi" id="2oJmO5LZ9VJ" role="33vP2m">
+                <node concept="2YIFZM" id="2oJmO5LZaNv" role="2Oq$k0">
+                  <ref role="37wK5l" to="96gm:2oJmO5LUeQ4" resolve="let" />
+                  <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+                  <node concept="2YIFZM" id="2oJmO5LZbz8" role="37wK5m">
+                    <ref role="37wK5l" to="96gm:2oJmO5LUeQ4" resolve="let" />
+                    <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+                    <node concept="2YIFZM" id="2oJmO5LZbz9" role="37wK5m">
+                      <ref role="37wK5l" to="96gm:2oJmO5LUeQ4" resolve="let" />
+                      <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+                      <node concept="2YIFZM" id="2oJmO5LZbMV" role="37wK5m">
+                        <ref role="37wK5l" to="96gm:2oJmO5LUeQ4" resolve="let" />
+                        <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+                        <node concept="2ShNRf" id="2oJmO5LZbMW" role="37wK5m">
+                          <node concept="1pGfFk" id="2oJmO5LZbMX" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+                          </node>
+                        </node>
+                        <node concept="1bVj0M" id="2oJmO5LZbMY" role="37wK5m">
+                          <node concept="3clFbS" id="2oJmO5LZbMZ" role="1bW5cS">
+                            <node concept="3clFbF" id="2oJmO5LZbN0" role="3cqZAp">
+                              <node concept="2OqwBi" id="2oJmO5LZbN1" role="3clFbG">
+                                <node concept="37vLTw" id="2oJmO5LZbN2" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="2oJmO5LZbN5" resolve="builder" />
+                                </node>
+                                <node concept="liA8E" id="2oJmO5LZbN3" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                                  <node concept="Xl_RD" id="2oJmO5LZbN4" role="37wK5m">
+                                    <property role="Xl_RC" value="Hello" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="37vLTG" id="2oJmO5LZbN5" role="1bW2Oz">
+                            <property role="TrG5h" value="builder" />
+                            <node concept="3uibUv" id="2oJmO5LZbN6" role="1tU5fm">
+                              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1bVj0M" id="2oJmO5LZbzm" role="37wK5m">
+                        <node concept="3clFbS" id="2oJmO5LZbzn" role="1bW5cS">
+                          <node concept="3clFbF" id="2oJmO5LZbzo" role="3cqZAp">
+                            <node concept="2OqwBi" id="2oJmO5LZbzp" role="3clFbG">
+                              <node concept="37vLTw" id="2oJmO5LZbzq" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2oJmO5LZbzt" resolve="builder" />
+                              </node>
+                              <node concept="liA8E" id="2oJmO5LZbzr" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                                <node concept="Xl_RD" id="2oJmO5LZbzs" role="37wK5m">
+                                  <property role="Xl_RC" value=", " />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="37vLTG" id="2oJmO5LZbzt" role="1bW2Oz">
+                          <property role="TrG5h" value="builder" />
+                          <node concept="3uibUv" id="2oJmO5LZbzu" role="1tU5fm">
+                            <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1bVj0M" id="2oJmO5LZbzv" role="37wK5m">
+                      <node concept="3clFbS" id="2oJmO5LZbzw" role="1bW5cS">
+                        <node concept="3clFbF" id="2oJmO5LZbzx" role="3cqZAp">
+                          <node concept="2OqwBi" id="2oJmO5LZbzy" role="3clFbG">
+                            <node concept="37vLTw" id="2oJmO5LZbzz" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2oJmO5LZbzA" resolve="builder" />
+                            </node>
+                            <node concept="liA8E" id="2oJmO5LZbz$" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                              <node concept="Xl_RD" id="2oJmO5LZbz_" role="37wK5m">
+                                <property role="Xl_RC" value="World" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="37vLTG" id="2oJmO5LZbzA" role="1bW2Oz">
+                        <property role="TrG5h" value="builder" />
+                        <node concept="3uibUv" id="2oJmO5LZbzB" role="1tU5fm">
+                          <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1bVj0M" id="2oJmO5LZaO0" role="37wK5m">
+                    <node concept="3clFbS" id="2oJmO5LZaO1" role="1bW5cS">
+                      <node concept="3clFbF" id="2oJmO5LZaO2" role="3cqZAp">
+                        <node concept="2OqwBi" id="2oJmO5LZaO3" role="3clFbG">
+                          <node concept="37vLTw" id="2oJmO5LZaO4" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2oJmO5LZaO7" resolve="builder" />
+                          </node>
+                          <node concept="liA8E" id="2oJmO5LZaO5" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                            <node concept="Xl_RD" id="2oJmO5LZaO6" role="37wK5m">
+                              <property role="Xl_RC" value="!" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="2oJmO5LZaO7" role="1bW2Oz">
+                      <property role="TrG5h" value="builder" />
+                      <node concept="3uibUv" id="2oJmO5LZaO8" role="1tU5fm">
+                        <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="2oJmO5LZ9Wq" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2oJmO5LZ9Wr" role="3cqZAp" />
+          <node concept="3vlDli" id="2oJmO5LZ9Ws" role="3cqZAp">
+            <node concept="Xl_RD" id="2oJmO5LZ9Wt" role="3tpDZB">
+              <property role="Xl_RC" value="Hello, World!" />
+            </node>
+            <node concept="37vLTw" id="2oJmO5LZ9Wu" role="3tpDZA">
+              <ref role="3cqZAo" node="2oJmO5LZ9VH" resolve="actual" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="2oJmO5LYbe8" role="3s_gse">
+        <property role="3s$Bm0" value="chainPrint" />
+        <node concept="3cqZAl" id="2oJmO5LYbe9" role="3clF45" />
+        <node concept="3Tm1VV" id="2oJmO5LYbea" role="1B3o_S" />
+        <node concept="3clFbS" id="2oJmO5LYbeb" role="3clF47">
+          <node concept="3SKdUt" id="2oJmO5LZq_M" role="3cqZAp">
+            <node concept="1PaTwC" id="2oJmO5LZq_N" role="1aUNEU">
+              <node concept="3oM_SD" id="2oJmO5LZqMQ" role="1PaTwD">
+                <property role="3oM_SC" value="this" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqMR" role="1PaTwD">
+                <property role="3oM_SC" value="is" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqMS" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqMT" role="1PaTwD">
+                <property role="3oM_SC" value="actual" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqMU" role="1PaTwD">
+                <property role="3oM_SC" value="value" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqMV" role="1PaTwD">
+                <property role="3oM_SC" value="of" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqMW" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqMX" role="1PaTwD">
+                <property role="3oM_SC" value="apply" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqMY" role="1PaTwD">
+                <property role="3oM_SC" value="functionality," />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqMZ" role="1PaTwD">
+                <property role="3oM_SC" value="even" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqN0" role="1PaTwD">
+                <property role="3oM_SC" value="if" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqN1" role="1PaTwD">
+                <property role="3oM_SC" value="a" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqN2" role="1PaTwD">
+                <property role="3oM_SC" value="but" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqN3" role="1PaTwD">
+                <property role="3oM_SC" value="clunky" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqN4" role="1PaTwD">
+                <property role="3oM_SC" value="in" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqN5" role="1PaTwD">
+                <property role="3oM_SC" value="&quot;runtime&quot;" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZqN6" role="1PaTwD">
+                <property role="3oM_SC" value="style" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="2oJmO5LYbec" role="3cqZAp">
+            <node concept="3cpWsn" id="2oJmO5LYbed" role="3cpWs9">
+              <property role="TrG5h" value="actual" />
+              <node concept="3uibUv" id="2oJmO5LYbee" role="1tU5fm">
+                <ref role="3uigEE" to="guwi:~PrintStream" resolve="PrintStream" />
+              </node>
+              <node concept="2YIFZM" id="2oJmO5LZ1Aw" role="33vP2m">
+                <ref role="37wK5l" to="96gm:2oJmO5LXrKn" resolve="applyVoid" />
+                <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+                <node concept="2YIFZM" id="2oJmO5LZgUj" role="37wK5m">
+                  <ref role="37wK5l" to="96gm:2oJmO5LXrKn" resolve="applyVoid" />
+                  <ref role="1Pybhc" to="96gm:2oJmO5LUej2" resolve="ScopeFunctionUtil" />
+                  <node concept="10M0yZ" id="2oJmO5LZgUk" role="37wK5m">
+                    <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                    <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                  </node>
+                  <node concept="1bVj0M" id="2oJmO5LZgUl" role="37wK5m">
+                    <node concept="3clFbS" id="2oJmO5LZgUm" role="1bW5cS">
+                      <node concept="3clFbF" id="2oJmO5LZgUn" role="3cqZAp">
+                        <node concept="2OqwBi" id="2oJmO5LZgUo" role="3clFbG">
+                          <node concept="37vLTw" id="2oJmO5LZgUp" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2oJmO5LZgUs" resolve="out" />
+                          </node>
+                          <node concept="liA8E" id="2oJmO5LZgUq" role="2OqNvi">
+                            <ref role="37wK5l" to="guwi:~PrintStream.print(java.lang.String)" resolve="print" />
+                            <node concept="Xl_RD" id="2oJmO5LZgUr" role="37wK5m">
+                              <property role="Xl_RC" value="Hello, " />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="2oJmO5LZgUs" role="1bW2Oz">
+                      <property role="TrG5h" value="out" />
+                      <node concept="3uibUv" id="2oJmO5LZgUt" role="1tU5fm">
+                        <ref role="3uigEE" to="guwi:~PrintStream" resolve="PrintStream" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1bVj0M" id="2oJmO5LZ1Ay" role="37wK5m">
+                  <node concept="3clFbS" id="2oJmO5LZ1Az" role="1bW5cS">
+                    <node concept="3clFbF" id="2oJmO5LZ1A$" role="3cqZAp">
+                      <node concept="2OqwBi" id="2oJmO5LZ1A_" role="3clFbG">
+                        <node concept="37vLTw" id="2oJmO5LZ1AA" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2oJmO5LZ1AD" resolve="out" />
+                        </node>
+                        <node concept="liA8E" id="2oJmO5LZ1AB" role="2OqNvi">
+                          <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                          <node concept="Xl_RD" id="2oJmO5LZ1AC" role="37wK5m">
+                            <property role="Xl_RC" value="World!" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTG" id="2oJmO5LZ1AD" role="1bW2Oz">
+                    <property role="TrG5h" value="out" />
+                    <node concept="3uibUv" id="2oJmO5LZ1AE" role="1tU5fm">
+                      <ref role="3uigEE" to="guwi:~PrintStream" resolve="PrintStream" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2oJmO5LYbet" role="3cqZAp" />
+          <node concept="3SKdUt" id="2oJmO5LZfnR" role="3cqZAp">
+            <node concept="1PaTwC" id="2oJmO5LZfnS" role="1aUNEU">
+              <node concept="3oM_SD" id="2oJmO5LZfqT" role="1PaTwD">
+                <property role="3oM_SC" value="we" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZfqU" role="1PaTwD">
+                <property role="3oM_SC" value="explicitly" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZfqV" role="1PaTwD">
+                <property role="3oM_SC" value="want" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZfqW" role="1PaTwD">
+                <property role="3oM_SC" value="to" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZfqX" role="1PaTwD">
+                <property role="3oM_SC" value="check" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZfqY" role="1PaTwD">
+                <property role="3oM_SC" value="for" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZfqZ" role="1PaTwD">
+                <property role="3oM_SC" value="identify" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZfr0" role="1PaTwD">
+                <property role="3oM_SC" value="here," />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZfr1" role="1PaTwD">
+                <property role="3oM_SC" value="not" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZfr2" role="1PaTwD">
+                <property role="3oM_SC" value="just" />
+              </node>
+              <node concept="3oM_SD" id="2oJmO5LZfr3" role="1PaTwD">
+                <property role="3oM_SC" value="equality" />
+              </node>
+            </node>
+          </node>
+          <node concept="3vwNmj" id="2oJmO5LZekU" role="3cqZAp">
+            <node concept="3clFbC" id="2oJmO5LZf90" role="3vwVQn">
+              <node concept="37vLTw" id="2oJmO5LZfhY" role="3uHU7w">
+                <ref role="3cqZAo" node="2oJmO5LYbed" resolve="actual" />
+              </node>
+              <node concept="10M0yZ" id="2oJmO5LZeK0" role="3uHU7B">
+                <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.withIndexOperation@tests.mps
+++ b/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.withIndexOperation@tests.mps
@@ -193,7 +193,7 @@
               </node>
               <node concept="2YIFZM" id="7Ja64GBcext" role="33vP2m">
                 <ref role="37wK5l" to="96gm:7Ja64GBadQG" resolve="selectWithIndex" />
-                <ref role="1Pybhc" to="96gm:7Ja64GBadPz" resolve="SelectWithIndexOperationUtil" />
+                <ref role="1Pybhc" to="96gm:7Ja64GBadPz" resolve="WithIndexOperationUtil" />
                 <node concept="37vLTw" id="7Ja64GBcexu" role="37wK5m">
                   <ref role="3cqZAo" node="7Ja64GBcaru" resolve="nums" />
                 </node>


### PR DESCRIPTION
## Name
Scope Function Operations (apply, let)

## Operation Type
DotExpression

## Use Case
When writing code in a more FP-style, but when you you want to apply more complex operations to atomic values (not sequences), then you are lacking some core functionality that would be trivial on a sequence. For example, there so far is no equivalent for a `select` on atomic values. Here, the scope functions come to rescue: The new `let` function is effectively a `select` for individual values, if you don't want to introduce the operation as its own function. And `apply` lets you do "side-effects" effectively, while preserving the callee's identity. Also useful for method chaining, if the type at hand doesn't tend to return itself on any method invocation.

## Comments
Kotlin offers four different scope functions that are also extension methods, but they effectively form two pairs of two operations that semantically are quite similar. We decided to only have one per group and therefore quasi dropping the variant which would use `this` to address the captured value.