### PR TITLE
Add type alias to new language baseLanguageExtensions

### DIFF
--- a/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:dae58e0d-cfc8-4c6e-929d-37b22f4242e5(de.itemis.mps.baseLanguageExtensions.sandbox)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="52b771c2-b79f-4f44-98f2-d24fd25a210b" name="de.itemis.mps.baseLanguageExtensions" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
@@ -9,6 +10,7 @@
   </languages>
   <imports>
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -38,6 +40,9 @@
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
@@ -51,6 +56,9 @@
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -98,12 +106,17 @@
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
+        <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
+        <child id="1212687122400" name="typeParameter" index="1pMfVU" />
       </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -116,6 +129,7 @@
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -137,12 +151,16 @@
       <concept id="7915817776605258993" name="de.itemis.mps.baseLanguageExtensions.structure.SelectWithIndexOperation" flags="ng" index="2kBsqy" />
       <concept id="5842252078326680676" name="de.itemis.mps.baseLanguageExtensions.structure.GroupByOperation" flags="ng" index="2pSdkF" />
       <concept id="7488777117048605758" name="de.itemis.mps.baseLanguageExtensions.structure.ZipOperation" flags="ng" index="Kbfsy" />
+      <concept id="4249150113556205385" name="de.itemis.mps.baseLanguageExtensions.structure.TypeAliasDeclaration" flags="ng" index="3hb0Na">
+        <child id="4249150113556205482" name="type" index="3hb0KD" />
+      </concept>
+      <concept id="4249150113556415229" name="de.itemis.mps.baseLanguageExtensions.structure.TypeAliasType" flags="ig" index="3hbO5Y" />
       <concept id="2751518233990321717" name="de.itemis.mps.baseLanguageExtensions.structure.ScopeFunctionOperation" flags="ng" index="1kbSPO">
         <child id="2751518233990321719" name="closure" index="1kbSPQ" />
       </concept>
       <concept id="2751518233990321721" name="de.itemis.mps.baseLanguageExtensions.structure.ApplyScopeFunctionOperation" flags="ng" index="1kbSPS" />
       <concept id="2751518233990321724" name="de.itemis.mps.baseLanguageExtensions.structure.LetScopeFunctionOperation" flags="ng" index="1kbSPX" />
-      <concept id="5566040892496752333" name="de.itemis.mps.baseLanguageExtensions.structure.SmartAtomicClosureParameterDeclaration" flags="ig" index="3nFU9Y" />
+      <concept id="5566040892496752333" name="de.itemis.mps.baseLanguageExtensions.structure.SmartAtomicClosureParameterDeclaration" flags="ng" index="3nFU9Y" />
       <concept id="8919968723020343837" name="de.itemis.mps.baseLanguageExtensions.structure.ForEachWithIndexOperation" flags="ng" index="1sWJ9m" />
       <concept id="8919968723020245069" name="de.itemis.mps.baseLanguageExtensions.structure.WhereWithIndexOperation" flags="ng" index="1sZn06" />
       <concept id="578371460444482140" name="de.itemis.mps.baseLanguageExtensions.structure.ElvisOperation" flags="ng" index="1w0Eer" />
@@ -1586,6 +1604,169 @@
       <node concept="3cqZAl" id="2oJmO5M1vRm" role="3clF45" />
     </node>
     <node concept="3Tm1VV" id="2oJmO5M1vQd" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="7BsoQawx9nN">
+    <property role="TrG5h" value="TypeAliasSandbox" />
+    <node concept="3hb0Na" id="7BsoQawx9qG" role="jymVt">
+      <property role="TrG5h" value="OptStr" />
+      <node concept="3Tm1VV" id="7BsoQawx9qH" role="1B3o_S" />
+      <node concept="3uibUv" id="7BsoQawx9rg" role="3hb0KD">
+        <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+        <node concept="17QB3L" id="7BsoQawx9rv" role="11_B2D" />
+      </node>
+    </node>
+    <node concept="3hb0Na" id="7BsoQawx9sF" role="jymVt">
+      <property role="TrG5h" value="MapStrToIntList" />
+      <node concept="3Tm1VV" id="7BsoQawx9sG" role="1B3o_S" />
+      <node concept="3uibUv" id="7BsoQawxG$N" role="3hb0KD">
+        <ref role="3uigEE" to="33ny:~HashMap" resolve="HashMap" />
+        <node concept="17QB3L" id="7BsoQawxGVA" role="11_B2D" />
+        <node concept="_YKpA" id="7BsoQawxHiX" role="11_B2D">
+          <node concept="10Oyi0" id="7BsoQawxHvh" role="_ZDj9" />
+        </node>
+      </node>
+    </node>
+    <node concept="2YIFZL" id="7BsoQawx9px" role="jymVt">
+      <property role="TrG5h" value="usages" />
+      <node concept="3clFbS" id="7BsoQawx9p$" role="3clF47">
+        <node concept="3cpWs8" id="7BsoQawx9vu" role="3cqZAp">
+          <node concept="3cpWsn" id="7BsoQawx9vx" role="3cpWs9">
+            <property role="TrG5h" value="opt" />
+            <node concept="3hbO5Y" id="7BsoQawxnbp" role="1tU5fm">
+              <ref role="3uigEE" node="7BsoQawx9qG" resolve="OptStr" />
+            </node>
+            <node concept="2YIFZM" id="7BsoQawx9Eb" role="33vP2m">
+              <ref role="37wK5l" to="33ny:~Optional.ofNullable(java.lang.Object)" resolve="ofNullable" />
+              <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+              <node concept="17QB3L" id="7BsoQawx9Ja" role="3PaCim" />
+              <node concept="10Nm6u" id="7BsoQawx9M9" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7BsoQawxnhc" role="3cqZAp">
+          <node concept="2OqwBi" id="7BsoQawxnsJ" role="3clFbG">
+            <node concept="37vLTw" id="7BsoQawxnha" role="2Oq$k0">
+              <ref role="3cqZAo" node="7BsoQawx9vx" resolve="opt" />
+            </node>
+            <node concept="liA8E" id="7BsoQawxnBd" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.ifPresent(java.util.function.Consumer)" resolve="ifPresent" />
+              <node concept="1bVj0M" id="7BsoQawxoRY" role="37wK5m">
+                <node concept="37vLTG" id="7BsoQawxoYv" role="1bW2Oz">
+                  <property role="TrG5h" value="s" />
+                  <node concept="17QB3L" id="7BsoQawxoYx" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="7BsoQawxoRZ" role="1bW5cS">
+                  <node concept="3clFbF" id="7BsoQawxp9t" role="3cqZAp">
+                    <node concept="2OqwBi" id="7BsoQawxp9q" role="3clFbG">
+                      <node concept="10M0yZ" id="7BsoQawxp9r" role="2Oq$k0">
+                        <ref role="1PxDUh" to="wyt6:~System" />
+                        <ref role="3cqZAo" to="wyt6:~System.out" />
+                      </node>
+                      <node concept="liA8E" id="7BsoQawxp9s" role="2OqNvi">
+                        <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                        <node concept="37vLTw" id="7BsoQawxpfg" role="37wK5m">
+                          <ref role="3cqZAo" node="7BsoQawxoYv" resolve="s" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7BsoQawxpCs" role="3cqZAp" />
+        <node concept="3cpWs8" id="7BsoQawxy0Q" role="3cqZAp">
+          <node concept="3cpWsn" id="7BsoQawxy0R" role="3cpWs9">
+            <property role="TrG5h" value="map" />
+            <node concept="3hbO5Y" id="7BsoQawxyDA" role="1tU5fm">
+              <ref role="3uigEE" node="7BsoQawx9sF" resolve="MapStrToIntList" />
+            </node>
+            <node concept="2ShNRf" id="7BsoQawx$yW" role="33vP2m">
+              <node concept="1pGfFk" id="7BsoQawxHTV" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="33ny:~HashMap.&lt;init&gt;()" resolve="HashMap" />
+                <node concept="17QB3L" id="7BsoQawxIa5" role="1pMfVU" />
+                <node concept="_YKpA" id="7BsoQawxIxp" role="1pMfVU">
+                  <node concept="10Oyi0" id="7BsoQawxIUO" role="_ZDj9" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7BsoQawx_Dq" role="3cqZAp">
+          <node concept="2OqwBi" id="7BsoQawxTeE" role="3clFbG">
+            <node concept="37vLTw" id="7BsoQawx_Do" role="2Oq$k0">
+              <ref role="3cqZAo" node="7BsoQawxy0R" resolve="map" />
+            </node>
+            <node concept="liA8E" id="7BsoQawxTWo" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="Xl_RD" id="7BsoQawxUmP" role="37wK5m">
+                <property role="Xl_RC" value="test" />
+              </node>
+              <node concept="2ShNRf" id="7BsoQawxVMy" role="37wK5m">
+                <node concept="Tc6Ow" id="7BsoQawxVp8" role="2ShVmc">
+                  <node concept="10Oyi0" id="7BsoQawxVp9" role="HW$YZ" />
+                  <node concept="3cmrfG" id="7BsoQawxXBr" role="HW$Y0">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                  <node concept="3cmrfG" id="7BsoQawxXB_" role="HW$Y0">
+                    <property role="3cmrfH" value="2" />
+                  </node>
+                  <node concept="3cmrfG" id="7BsoQawxXSW" role="HW$Y0">
+                    <property role="3cmrfH" value="3" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7BsoQawxYGT" role="3cqZAp">
+          <node concept="2OqwBi" id="7BsoQawxYGU" role="3clFbG">
+            <node concept="37vLTw" id="7BsoQawxYGV" role="2Oq$k0">
+              <ref role="3cqZAo" node="7BsoQawxy0R" resolve="map" />
+            </node>
+            <node concept="liA8E" id="7BsoQawxYGW" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="Xl_RD" id="7BsoQawxYGX" role="37wK5m">
+                <property role="Xl_RC" value="test1" />
+              </node>
+              <node concept="2ShNRf" id="7BsoQawxYGY" role="37wK5m">
+                <node concept="Tc6Ow" id="7BsoQawxYGZ" role="2ShVmc">
+                  <node concept="10Oyi0" id="7BsoQawxYH0" role="HW$YZ" />
+                  <node concept="3cmrfG" id="7BsoQawy1od" role="HW$Y0">
+                    <property role="3cmrfH" value="3" />
+                  </node>
+                  <node concept="3cmrfG" id="7BsoQawy1Nr" role="HW$Y0">
+                    <property role="3cmrfH" value="4" />
+                  </node>
+                  <node concept="3cmrfG" id="7BsoQawy2eI" role="HW$Y0">
+                    <property role="3cmrfH" value="5" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7BsoQawy3pG" role="3cqZAp">
+          <node concept="2OqwBi" id="7BsoQawy3pD" role="3clFbG">
+            <node concept="10M0yZ" id="7BsoQawy3pE" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" />
+            </node>
+            <node concept="liA8E" id="7BsoQawy3pF" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.Object)" resolve="println" />
+              <node concept="37vLTw" id="7BsoQawy49X" role="37wK5m">
+                <ref role="3cqZAo" node="7BsoQawxy0R" resolve="map" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="7BsoQawx9pa" role="1B3o_S" />
+      <node concept="3cqZAl" id="7BsoQawx9pn" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="7BsoQawx9nO" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
@@ -30,6 +30,7 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -63,6 +64,7 @@
       <concept id="1114729360583" name="jetbrains.mps.lang.generator.structure.CopySrcListMacro" flags="ln" index="2b32R4">
         <child id="1168278589236" name="sourceNodesQuery" index="2P8S$" />
       </concept>
+      <concept id="1202776937179" name="jetbrains.mps.lang.generator.structure.AbandonInput_RuleConsequence" flags="lg" index="b5Tf3" />
       <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
         <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
       </concept>
@@ -1016,14 +1018,39 @@
         </node>
       </node>
     </node>
+    <node concept="3aamgX" id="2OpC$gsL7_M" role="3acgRq">
+      <ref role="30HIoZ" to="pkab:3FS0SfFPObX" resolve="TypeAliasType" />
+      <node concept="gft3U" id="2OpC$gsL8S3" role="1lVwrX">
+        <node concept="10Oyi0" id="2OpC$gsL8S7" role="gfFT$">
+          <node concept="29HgVG" id="2OpC$gsL8S9" role="lGtFl">
+            <node concept="3NFfHV" id="2OpC$gsL8Sa" role="3NFExx">
+              <node concept="3clFbS" id="2OpC$gsL8Sb" role="2VODD2">
+                <node concept="3clFbF" id="2OpC$gsL8Sh" role="3cqZAp">
+                  <node concept="2OqwBi" id="2OpC$gsL9KP" role="3clFbG">
+                    <node concept="2OqwBi" id="2OpC$gsL8Sc" role="2Oq$k0">
+                      <node concept="3TrEf2" id="2OpC$gsL8Sf" role="2OqNvi">
+                        <ref role="3Tt5mk" to="pkab:3FS0SfFPObY" resolve="typeAliasDeclaration" />
+                      </node>
+                      <node concept="30H73N" id="2OpC$gsL8Sg" role="2Oq$k0" />
+                    </node>
+                    <node concept="3TrEf2" id="2OpC$gsLauI" role="2OqNvi">
+                      <ref role="3Tt5mk" to="pkab:3FS0SfFP0YE" resolve="type" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="2OpC$gsOMDj" role="3acgRq">
+      <ref role="30HIoZ" to="pkab:3FS0SfFP0X9" resolve="TypeAliasDeclaration" />
+      <node concept="b5Tf3" id="2OpC$gsONV$" role="1lVwrX" />
+    </node>
   </node>
   <node concept="jVnub" id="54jQkZ9fKWX">
     <property role="TrG5h" value="switchClosureLiteral" />
-    <node concept="gft3U" id="54jQkZ9g94P" role="jxRDz">
-      <node concept="10Nm6u" id="54jQkZ9g97V" role="gfFT$">
-        <node concept="29HgVG" id="54jQkZ9g984" role="lGtFl" />
-      </node>
-    </node>
     <node concept="3aamgX" id="7Ja64GBawMh" role="3aUrZf">
       <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
@@ -1178,6 +1205,11 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="gft3U" id="54jQkZ9g94P" role="jxRDz">
+      <node concept="10Nm6u" id="54jQkZ9g97V" role="gfFT$">
+        <node concept="29HgVG" id="54jQkZ9g984" role="lGtFl" />
       </node>
     </node>
   </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.behavior.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.behavior.mps
@@ -6,7 +6,115 @@
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
+        <reference id="1225194240799" name="concept" index="13h7C2" />
+        <child id="1225194240805" name="method" index="13h7CS" />
+        <child id="1225194240801" name="constructor" index="13h7CW" />
+      </concept>
+      <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
+      <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz">
+        <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
+      </concept>
+      <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="13h7C7" id="3FS0SfFQscq">
+    <property role="3GE5qa" value="typeAlias" />
+    <ref role="13h7C2" to="pkab:3FS0SfFPObX" resolve="TypeAliasType" />
+    <node concept="13hLZK" id="3FS0SfFQscr" role="13h7CW">
+      <node concept="3clFbS" id="3FS0SfFQscs" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="3FS0SfFQscH" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="3FS0SfFQsd2" role="1B3o_S" />
+      <node concept="3clFbS" id="3FS0SfFQsd3" role="3clF47">
+        <node concept="3clFbF" id="3FS0SfFQsrx" role="3cqZAp">
+          <node concept="2OqwBi" id="3FS0SfFQtwO" role="3clFbG">
+            <node concept="2OqwBi" id="3FS0SfFQsIk" role="2Oq$k0">
+              <node concept="13iPFW" id="3FS0SfFQsrw" role="2Oq$k0" />
+              <node concept="3TrEf2" id="3FS0SfFQt2Q" role="2OqNvi">
+                <ref role="3Tt5mk" to="pkab:3FS0SfFPObY" resolve="typeAliasDeclaration" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="2OpC$gsQtbL" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="3FS0SfFQsd4" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="2OpC$gsQF3A">
+    <property role="3GE5qa" value="typeAlias" />
+    <ref role="13h7C2" to="pkab:3FS0SfFP0X9" resolve="TypeAliasDeclaration" />
+    <node concept="13hLZK" id="2OpC$gsQF3B" role="13h7CW">
+      <node concept="3clFbS" id="2OpC$gsQF3C" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="2OpC$gsQF3T" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="2OpC$gsQF40" role="1B3o_S" />
+      <node concept="3clFbS" id="2OpC$gsQF41" role="3clF47">
+        <node concept="3clFbF" id="2OpC$gsQFkC" role="3cqZAp">
+          <node concept="2OqwBi" id="2OpC$gsQFMd" role="3clFbG">
+            <node concept="13iPFW" id="2OpC$gsQFkB" role="2Oq$k0" />
+            <node concept="3TrcHB" id="2OpC$gsQGqK" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="2OpC$gsQF42" role="3clF45" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.constraints.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.constraints.mps
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:ef77ae2b-58ea-4c2a-9bab-de7fe5ec2b15(de.itemis.mps.baseLanguageExtensions.constraints)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
     <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
   </languages>
   <imports>
+    <import index="fnmy" ref="r:89c0fb70-0977-4113-a076-5906f9d8630f(jetbrains.mps.baseLanguage.scopes)" />
     <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
     <import index="tp2c" ref="r:00000000-0000-4000-0000-011c89590338(jetbrains.mps.baseLanguage.closures.structure)" implicit="true" />
     <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" implicit="true" />
@@ -20,6 +22,9 @@
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -39,6 +44,10 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
@@ -51,11 +60,18 @@
       <concept id="6702802731807351367" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAChild" flags="in" index="9S07l" />
       <concept id="6702802731807424858" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAnAncestor" flags="in" index="9SQb8" />
       <concept id="1202989658459" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_parentNode" flags="nn" index="nLn13" />
+      <concept id="8966504967485224688" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_contextNode" flags="nn" index="2rP1CM" />
       <concept id="4303308395523096213" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childConcept" flags="ng" index="2DD5aU" />
+      <concept id="5564765827938091039" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_ReferentSearchScope_Scope" flags="ig" index="3dgokm" />
       <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
         <reference id="1213093996982" name="concept" index="1M2myG" />
         <child id="6702802731807532730" name="canBeAncestor" index="9SGkC" />
         <child id="6702802731807737306" name="canBeChild" index="9Vyp8" />
+        <child id="1213100494875" name="referent" index="1Mr941" />
+      </concept>
+      <concept id="1148687176410" name="jetbrains.mps.lang.constraints.structure.NodeReferentConstraint" flags="ng" index="1N5Pfh">
+        <reference id="1148687202698" name="applicableLink" index="1N5Vy1" />
+        <child id="1148687345559" name="searchScopeFactory" index="1N6uqs" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -142,6 +158,25 @@
         </node>
         <node concept="3cpWs6" id="4OYzbeqXMGP" role="3cqZAp">
           <node concept="3clFbT" id="4OYzbeqXMIp" role="3cqZAk" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="3FS0SfFPPWy">
+    <property role="3GE5qa" value="typeAlias" />
+    <ref role="1M2myG" to="pkab:3FS0SfFPObX" resolve="TypeAliasType" />
+    <node concept="1N5Pfh" id="3FS0SfFPPWz" role="1Mr941">
+      <ref role="1N5Vy1" to="pkab:3FS0SfFPObY" resolve="typeAliasDeclaration" />
+      <node concept="3dgokm" id="3FS0SfFPPXm" role="1N6uqs">
+        <node concept="3clFbS" id="3FS0SfFPPXn" role="2VODD2">
+          <node concept="3clFbF" id="3FS0SfFPQ1x" role="3cqZAp">
+            <node concept="2YIFZM" id="3FS0SfFPQ5R" role="3clFbG">
+              <ref role="37wK5l" to="fnmy:7mWjQkQg3iP" resolve="getVisibleClassifiersScope" />
+              <ref role="1Pybhc" to="fnmy:7mWjQkQg3ix" resolve="ClassifierScopes" />
+              <node concept="2rP1CM" id="3FS0SfFPQ6Z" role="37wK5m" />
+              <node concept="3clFbT" id="3FS0SfFPQc2" role="37wK5m" />
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.editor.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.editor.mps
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:dca4ef47-9ba9-4d6c-8e06-d355b171ecdd(de.itemis.mps.baseLanguageExtensions.editor)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
+    <import index="fnmy" ref="r:89c0fb70-0977-4113-a076-5906f9d8630f(jetbrains.mps.baseLanguage.scopes)" />
     <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
     <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -25,6 +30,7 @@
       <concept id="6089045305654894367" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Named" flags="ng" index="2kknPI">
         <reference id="6089045305654944382" name="menu" index="2kkw0f" />
       </concept>
+      <concept id="6089045305654894366" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Default" flags="ng" index="2kknPJ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1177327274449" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_pattern" flags="nn" index="ub8z3" />
       <concept id="1177327570013" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Substitute" flags="in" index="ucgPf" />
@@ -35,6 +41,11 @@
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
+      <concept id="8371900013785948369" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Parameter" flags="ig" index="2$S_p_" />
+      <concept id="308059530142752797" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Parameterized" flags="ng" index="2F$Pav">
+        <child id="8371900013785948359" name="part" index="2$S_pN" />
+        <child id="8371900013785948365" name="parameterQuery" index="2$S_pT" />
+      </concept>
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
@@ -43,9 +54,16 @@
         <property id="1186414551515" name="flag" index="VOm3f" />
       </concept>
       <concept id="1186414949600" name="jetbrains.mps.lang.editor.structure.AutoDeletableStyleClassItem" flags="ln" index="VPRnO" />
+      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ng" index="2Z_bC8">
+        <reference id="1630016958698373342" name="concept" index="2ZyFGn" />
+      </concept>
       <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
         <child id="5991739802479788259" name="type" index="22hAXT" />
+      </concept>
+      <concept id="1630016958697286851" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_parameterObject" flags="ng" index="2ZBlsa" />
+      <concept id="1630016958697057551" name="jetbrains.mps.lang.editor.structure.IMenuPartParameterized" flags="ng" index="2ZBHr6">
+        <child id="1630016958697057552" name="parameterType" index="2ZBHrp" />
       </concept>
       <concept id="8998492695583109601" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_CanSubstitute" flags="ig" index="16Na2f" />
       <concept id="8998492695583125082" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_MatchingText" flags="ng" index="16NfWO">
@@ -54,19 +72,28 @@
       <concept id="8998492695583129991" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_CanSubstitute" flags="ng" index="16NL3D">
         <child id="8998492695583129992" name="query" index="16NL3A" />
       </concept>
+      <concept id="1154465273778" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_ParentNode" flags="nn" index="3bvxqY" />
       <concept id="7342352913006985483" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Action" flags="ng" index="3eGOop">
         <child id="8612453216082699922" name="substituteHandler" index="3aKz83" />
       </concept>
+      <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
+        <child id="1088186146602" name="editorComponent" index="1sWHZn" />
+      </concept>
       <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
+      </concept>
+      <concept id="3308396621974588243" name="jetbrains.mps.lang.editor.structure.SubstituteMenu_Contribution" flags="ng" index="3p309x">
+        <child id="7173407872095451092" name="menuReference" index="1IG6uw" />
       </concept>
       <concept id="7580468736840446506" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_model" flags="nn" index="1rpKSd" />
       <concept id="730181322658904464" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_IncludeMenu" flags="ng" index="1s_PAr">
         <child id="730181322658904467" name="menuReference" index="1s_PAo" />
       </concept>
+      <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
       <concept id="5425882385312046132" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_CurrentTargetNode" flags="nn" index="1yR$tW" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <property id="1139852716018" name="noTargetText" index="1$x2rV" />
+        <property id="1140017977771" name="readOnly" index="1Intyy" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
       <concept id="7991336459489871999" name="jetbrains.mps.lang.editor.structure.IOutputConceptSubstituteMenuPart" flags="ng" index="3EoQpk">
@@ -96,6 +123,7 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
@@ -105,6 +133,9 @@
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
@@ -137,6 +168,7 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -151,6 +183,10 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
       <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
@@ -160,6 +196,28 @@
         <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
+      </concept>
+    </language>
     <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
       <concept id="5480835971642155304" name="jetbrains.mps.lang.actions.structure.NF_Model_CreateNewNodeOperation" flags="nn" index="15TzpJ" />
     </language>
@@ -167,8 +225,12 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1143235216708" name="jetbrains.mps.lang.smodel.structure.Model_CreateNewNodeOperation" flags="nn" index="I8ghe">
         <reference id="1143235391024" name="concept" index="I8UWU" />
+      </concept>
+      <concept id="1182511038748" name="jetbrains.mps.lang.smodel.structure.Model_NodesIncludingImportedOperation" flags="nn" index="1j9C0f">
+        <child id="6750920497477143623" name="conceptArgument" index="3MHPCF" />
       </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
@@ -187,6 +249,13 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
     </language>
   </registry>
   <node concept="24kQdi" id="vJfcQmmcTO">
@@ -416,6 +485,34 @@
     <ref role="aqKnT" to="pkab:vJfcQmma$O" resolve="IntegerRangeConstantBound" />
     <node concept="22hDWj" id="6vHuLLnCVGp" role="22hAXT" />
   </node>
+  <node concept="24kQdi" id="3FS0SfFP1tJ">
+    <property role="3GE5qa" value="typeAlias" />
+    <ref role="1XX52x" to="pkab:3FS0SfFP0X9" resolve="TypeAliasDeclaration" />
+    <node concept="3EZMnI" id="3FS0SfFP1G0" role="2wV5jI">
+      <node concept="PMmxH" id="3FS0SfFP1G6" role="3EZMnx">
+        <ref role="PMmxG" to="tpen:h9AUA0X" resolve="_Component_Visibility" />
+      </node>
+      <node concept="PMmxH" id="3FS0SfFP1G8" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+        <ref role="1k5W1q" to="tpen:hgVS8CF" resolve="KeyWord" />
+      </node>
+      <node concept="3F0A7n" id="3FS0SfFP1Ga" role="3EZMnx">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+      <node concept="3F0ifn" id="3FS0SfFP1Gd" role="3EZMnx">
+        <property role="3F0ifm" value="=" />
+        <ref role="1k5W1q" to="tpen:hF$iUjy" resolve="Operator" />
+      </node>
+      <node concept="3F1sOY" id="3FS0SfFP1Gg" role="3EZMnx">
+        <ref role="1NtTu8" to="pkab:3FS0SfFP0YE" resolve="type" />
+      </node>
+      <node concept="l2Vlx" id="3FS0SfFP1G3" role="2iSdaV" />
+      <node concept="3F0ifn" id="3FS0SfFPhrQ" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <ref role="1k5W1q" to="tpen:hFDgi_W" resolve="Semicolon" />
+      </node>
+    </node>
+  </node>
   <node concept="24kQdi" id="2oJmO5M1wK0">
     <property role="3GE5qa" value="scopeFunction" />
     <ref role="1XX52x" to="pkab:2oJmO5M0doP" resolve="ScopeFunctionOperation" />
@@ -436,6 +533,113 @@
         <ref role="1k5W1q" to="tpen:hFCSUmN" resolve="RightParen" />
       </node>
       <node concept="2iRfu4" id="2oJmO5M1wK5" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="22mcaB" id="7BsoQawwJ4l">
+    <property role="3GE5qa" value="typeAlias" />
+    <ref role="aqKnT" to="pkab:3FS0SfFPObX" resolve="TypeAliasType" />
+    <node concept="22hDWj" id="7BsoQawwJ4m" role="22hAXT" />
+  </node>
+  <node concept="3p309x" id="2OpC$gsPYl1">
+    <property role="TrG5h" value="TypeAliasType_Contribution" />
+    <property role="3GE5qa" value="typeAlias" />
+    <node concept="2kknPJ" id="2OpC$gsPYl3" role="1IG6uw">
+      <ref role="2ZyFGn" to="tpee:fz3vP1H" resolve="Type" />
+    </node>
+    <node concept="2F$Pav" id="2OpC$gsPYl5" role="3ft7WO">
+      <node concept="3eGOop" id="2OpC$gsQbAi" role="2$S_pN">
+        <node concept="ucgPf" id="2OpC$gsQbAk" role="3aKz83">
+          <node concept="3clFbS" id="2OpC$gsQbAm" role="2VODD2">
+            <node concept="3clFbF" id="2OpC$gsQbHe" role="3cqZAp">
+              <node concept="2pJPEk" id="2OpC$gsQbK8" role="3clFbG">
+                <node concept="2pJPED" id="2OpC$gsQbKa" role="2pJPEn">
+                  <ref role="2pJxaS" to="pkab:3FS0SfFPObX" resolve="TypeAliasType" />
+                  <node concept="2pIpSj" id="2OpC$gsQbRQ" role="2pJxcM">
+                    <ref role="2pIpSl" to="pkab:3FS0SfFPObY" resolve="typeAliasDeclaration" />
+                    <node concept="36biLy" id="2OpC$gsQbVk" role="28nt2d">
+                      <node concept="2ZBlsa" id="2OpC$gsQbYQ" role="36biLW" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="16NfWO" id="2OpC$gsQc2p" role="upBLP">
+          <node concept="uGdhv" id="2OpC$gsQc3c" role="16NeZM">
+            <node concept="3clFbS" id="2OpC$gsQc3e" role="2VODD2">
+              <node concept="3clFbF" id="2OpC$gsQc9y" role="3cqZAp">
+                <node concept="3cpWs3" id="2OpC$gsQf1U" role="3clFbG">
+                  <node concept="Xl_RD" id="2OpC$gsQf2I" role="3uHU7w">
+                    <property role="Xl_RC" value=" type alias" />
+                  </node>
+                  <node concept="2OqwBi" id="2OpC$gsQcFB" role="3uHU7B">
+                    <node concept="2ZBlsa" id="2OpC$gsQc9x" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="2OpC$gsQdoO" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="2OpC$gsPYlc" role="2ZBHrp">
+        <ref role="ehGHo" to="pkab:3FS0SfFP0X9" resolve="TypeAliasDeclaration" />
+      </node>
+      <node concept="2$S_p_" id="2OpC$gsPYli" role="2$S_pT">
+        <node concept="3clFbS" id="2OpC$gsPYlj" role="2VODD2">
+          <node concept="3clFbF" id="2OpC$gsPYpp" role="3cqZAp">
+            <node concept="2OqwBi" id="2OpC$gsQ4li" role="3clFbG">
+              <node concept="2OqwBi" id="2OpC$gsPY$9" role="2Oq$k0">
+                <node concept="1rpKSd" id="2OpC$gsPYpo" role="2Oq$k0" />
+                <node concept="1j9C0f" id="2OpC$gsPYHh" role="2OqNvi">
+                  <node concept="chp4Y" id="2OpC$gsPYK3" role="3MHPCF">
+                    <ref role="cht4Q" to="pkab:3FS0SfFP0X9" resolve="TypeAliasDeclaration" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="2OpC$gsQ9d3" role="2OqNvi">
+                <node concept="1bVj0M" id="2OpC$gsQ9d5" role="23t8la">
+                  <node concept="3clFbS" id="2OpC$gsQ9d6" role="1bW5cS">
+                    <node concept="3clFbF" id="2OpC$gsQaX0" role="3cqZAp">
+                      <node concept="2YIFZM" id="2OpC$gsQbda" role="3clFbG">
+                        <ref role="37wK5l" to="fnmy:2Jvt1sWfuvb" resolve="isVisible" />
+                        <ref role="1Pybhc" to="fnmy:2Jvt1sWfuv6" resolve="VisibilityUtil" />
+                        <node concept="3bvxqY" id="2OpC$gsQbh7" role="37wK5m" />
+                        <node concept="37vLTw" id="2OpC$gsQbtp" role="37wK5m">
+                          <ref role="3cqZAo" node="2OpC$gsQ9d7" resolve="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="2OpC$gsQ9d7" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="2OpC$gsQ9d8" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="3FS0SfFPOc1">
+    <property role="3GE5qa" value="typeAlias" />
+    <ref role="1XX52x" to="pkab:3FS0SfFPObX" resolve="TypeAliasType" />
+    <node concept="3EZMnI" id="3FS0SfFPPSV" role="2wV5jI">
+      <node concept="1iCGBv" id="3FS0SfFPPT2" role="3EZMnx">
+        <ref role="1NtTu8" to="pkab:3FS0SfFPObY" resolve="typeAliasDeclaration" />
+        <node concept="1sVBvm" id="3FS0SfFPPT4" role="1sWHZn">
+          <node concept="3F0A7n" id="3FS0SfFPPT8" role="2wV5jI">
+            <property role="1Intyy" value="true" />
+            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          </node>
+        </node>
+      </node>
+      <node concept="l2Vlx" id="3FS0SfFPPSY" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
@@ -36,6 +36,7 @@
         <property id="1071599893252" name="sourceCardinality" index="20lbJX" />
         <property id="1071599937831" name="metaClass" index="20lmBu" />
         <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599698500" name="specializedLink" index="20ksaX" />
         <reference id="1071599976176" name="target" index="20lvS9" />
       </concept>
     </language>
@@ -129,11 +130,11 @@
     <property role="3GE5qa" value="groupByOperation" />
     <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
   </node>
-  <node concept="1TIwiD" id="7Ja64GBeeCt">
-    <property role="EcuMT" value="8919968723020343837" />
-    <property role="TrG5h" value="ForEachWithIndexOperation" />
-    <property role="34LRSv" value="forEachIdx" />
-    <property role="R4oN_" value="execute for each element with index" />
+  <node concept="1TIwiD" id="6RqC_fThQjL">
+    <property role="EcuMT" value="7915817776605258993" />
+    <property role="TrG5h" value="SelectWithIndexOperation" />
+    <property role="34LRSv" value="selectIdx" />
+    <property role="R4oN_" value="transform each element and index" />
     <property role="3GE5qa" value="withIndexOperations" />
     <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
   </node>
@@ -145,13 +146,35 @@
     <property role="3GE5qa" value="withIndexOperations" />
     <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
   </node>
-  <node concept="1TIwiD" id="6RqC_fThQjL">
-    <property role="EcuMT" value="7915817776605258993" />
-    <property role="TrG5h" value="SelectWithIndexOperation" />
-    <property role="34LRSv" value="selectIdx" />
-    <property role="R4oN_" value="transform each element and index" />
+  <node concept="1TIwiD" id="7Ja64GBeeCt">
+    <property role="EcuMT" value="8919968723020343837" />
+    <property role="TrG5h" value="ForEachWithIndexOperation" />
+    <property role="34LRSv" value="forEachIdx" />
+    <property role="R4oN_" value="execute for each element with index" />
     <property role="3GE5qa" value="withIndexOperations" />
     <ref role="1TJDcQ" to="tp2q:hy3sC_q" resolve="InternalSequenceOperation" />
+  </node>
+  <node concept="1TIwiD" id="3FS0SfFPObX">
+    <property role="EcuMT" value="4249150113556415229" />
+    <property role="TrG5h" value="TypeAliasType" />
+    <property role="R4oN_" value="reference to a type alias" />
+    <property role="3GE5qa" value="typeAlias" />
+    <ref role="1TJDcQ" to="tpee:g7uibYu" resolve="ClassifierType" />
+    <node concept="1TJgyj" id="3FS0SfFPObY" role="1TKVEi">
+      <property role="IQ2ns" value="4249150113556415230" />
+      <property role="20kJfa" value="typeAliasDeclaration" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="3FS0SfFP0X9" resolve="TypeAliasDeclaration" />
+      <ref role="20ksaX" to="tpee:g7uigIF" resolve="classifier" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="4OYzbeq$iVd">
+    <property role="EcuMT" value="5566040892496752333" />
+    <property role="3GE5qa" value="scopeFunction" />
+    <property role="TrG5h" value="SmartAtomicClosureParameterDeclaration" />
+    <property role="34LRSv" value="~ &lt;name&gt;" />
+    <property role="R4oN_" value="smart closure parameter" />
+    <ref role="1TJDcQ" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
   </node>
   <node concept="1TIwiD" id="2oJmO5M0doW">
     <property role="EcuMT" value="2751518233990321724" />
@@ -160,6 +183,21 @@
     <property role="34LRSv" value="let" />
     <property role="R4oN_" value="select anything from any object/instance" />
     <ref role="1TJDcQ" node="2oJmO5M0doP" resolve="ScopeFunctionOperation" />
+  </node>
+  <node concept="1TIwiD" id="3FS0SfFP0X9">
+    <property role="EcuMT" value="4249150113556205385" />
+    <property role="TrG5h" value="TypeAliasDeclaration" />
+    <property role="34LRSv" value="type alias" />
+    <property role="R4oN_" value="Type alias declaration" />
+    <property role="3GE5qa" value="typeAlias" />
+    <ref role="1TJDcQ" to="tpee:g7pOWCK" resolve="Classifier" />
+    <node concept="1TJgyj" id="3FS0SfFP0YE" role="1TKVEi">
+      <property role="IQ2ns" value="4249150113556205482" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="type" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpee:fz3vP1H" resolve="Type" />
+    </node>
   </node>
   <node concept="1TIwiD" id="2oJmO5M0doT">
     <property role="EcuMT" value="2751518233990321721" />
@@ -185,14 +223,6 @@
       <property role="20lbJX" value="fLJekj4/_1" />
       <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
     </node>
-  </node>
-  <node concept="1TIwiD" id="4OYzbeq$iVd">
-    <property role="EcuMT" value="5566040892496752333" />
-    <property role="3GE5qa" value="scopeFunction" />
-    <property role="TrG5h" value="SmartAtomicClosureParameterDeclaration" />
-    <property role="34LRSv" value="~ &lt;name&gt;" />
-    <property role="R4oN_" value="smart closure parameter" />
-    <ref role="1TJDcQ" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
@@ -119,6 +119,9 @@
         <child id="1195213635060" name="body" index="18ibNy" />
       </concept>
       <concept id="1195214364922" name="jetbrains.mps.lang.typesystem.structure.NonTypesystemRule" flags="ig" index="18kY7G" />
+      <concept id="6405009306797516074" name="jetbrains.mps.lang.typesystem.structure.SubstituteTypeRule" flags="ig" index="3qnSWH">
+        <child id="7323318266641100480" name="body" index="3hT0BD" />
+      </concept>
       <concept id="3937244445246642777" name="jetbrains.mps.lang.typesystem.structure.AbstractReportStatement" flags="ng" index="1urrMJ">
         <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
       </concept>
@@ -898,6 +901,66 @@
       <ref role="1YaFvo" to="pkab:6RqC_fThQjL" resolve="SelectWithIndexOperation" />
     </node>
   </node>
+  <node concept="1YbPZF" id="7Ja64GBdQEI">
+    <property role="TrG5h" value="typeof_WhereWithIndexOperation" />
+    <property role="3GE5qa" value="withIndexOperations" />
+    <node concept="3clFbS" id="7Ja64GBdQEJ" role="18ibNy">
+      <node concept="1ZxtTE" id="hwyZbXq" role="3cqZAp">
+        <property role="TrG5h" value="paramType" />
+      </node>
+      <node concept="3clFbF" id="34jUqC_VPJv" role="3cqZAp">
+        <node concept="2YIFZM" id="34jUqC_VR5x" role="3clFbG">
+          <ref role="37wK5l" to="tp2v:4Iwp2tSBzXf" resolve="inferInternalOperation" />
+          <ref role="1Pybhc" to="tp2v:4Iwp2tSBvWa" resolve="OperationInference" />
+          <node concept="1YBJjd" id="34jUqC_VR5y" role="37wK5m">
+            <ref role="1YBMHb" node="7Ja64GBdQEL" resolve="whereIdxOp" />
+          </node>
+          <node concept="1Z$b5t" id="34jUqC_VR5z" role="37wK5m">
+            <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
+          </node>
+          <node concept="2c44tf" id="7Ja64GBdQER" role="37wK5m">
+            <node concept="1ajhzC" id="7Ja64GBdQES" role="2c44tc">
+              <node concept="33vP2l" id="7Ja64GBdQET" role="1ajw0F">
+                <node concept="2c44te" id="7Ja64GBdQEU" role="lGtFl">
+                  <node concept="1Z$b5t" id="7Ja64GBdQEV" role="2c44t1">
+                    <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="10Oyi0" id="7Ja64GBdR9R" role="1ajw0F" />
+              <node concept="10P_77" id="34jUqC_VR5D" role="1ajl9A" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1Z5TYs" id="hwyZxSY" role="3cqZAp">
+        <node concept="mw_s8" id="hwyZRij" role="1ZfhKB">
+          <node concept="2c44tf" id="hwyZRik" role="mwGJk">
+            <node concept="A3Dl8" id="hwyZRB2" role="2c44tc">
+              <node concept="33vP2l" id="hwyZRB3" role="A3Ik2">
+                <node concept="2c44te" id="hwyZRRP" role="lGtFl">
+                  <node concept="1Z$b5t" id="hwyZS6_" role="2c44t1">
+                    <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hwyZxT1" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hwyZwPr" role="mwGJk">
+            <node concept="1YBJjd" id="hwyZxjd" role="1Z2MuG">
+              <ref role="1YBMHb" node="7Ja64GBdQEL" resolve="whereIdxOp" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7Ja64GBdQEL" role="1YuTPh">
+      <property role="TrG5h" value="whereIdxOp" />
+      <ref role="1YaFvo" to="pkab:7Ja64GBdQxd" resolve="WhereWithIndexOperation" />
+    </node>
+  </node>
   <node concept="1YbPZF" id="7Ja64GBegld">
     <property role="TrG5h" value="typeof_ForEachWithIndexOperation" />
     <property role="3GE5qa" value="withIndexOperations" />
@@ -993,66 +1056,6 @@
       <ref role="1YaFvo" to="pkab:7Ja64GBeeCt" resolve="ForEachWithIndexOperation" />
     </node>
   </node>
-  <node concept="1YbPZF" id="7Ja64GBdQEI">
-    <property role="TrG5h" value="typeof_WhereWithIndexOperation" />
-    <property role="3GE5qa" value="withIndexOperations" />
-    <node concept="3clFbS" id="7Ja64GBdQEJ" role="18ibNy">
-      <node concept="1ZxtTE" id="hwyZbXq" role="3cqZAp">
-        <property role="TrG5h" value="paramType" />
-      </node>
-      <node concept="3clFbF" id="34jUqC_VPJv" role="3cqZAp">
-        <node concept="2YIFZM" id="34jUqC_VR5x" role="3clFbG">
-          <ref role="37wK5l" to="tp2v:4Iwp2tSBzXf" resolve="inferInternalOperation" />
-          <ref role="1Pybhc" to="tp2v:4Iwp2tSBvWa" resolve="OperationInference" />
-          <node concept="1YBJjd" id="34jUqC_VR5y" role="37wK5m">
-            <ref role="1YBMHb" node="7Ja64GBdQEL" resolve="whereIdxOp" />
-          </node>
-          <node concept="1Z$b5t" id="34jUqC_VR5z" role="37wK5m">
-            <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
-          </node>
-          <node concept="2c44tf" id="7Ja64GBdQER" role="37wK5m">
-            <node concept="1ajhzC" id="7Ja64GBdQES" role="2c44tc">
-              <node concept="33vP2l" id="7Ja64GBdQET" role="1ajw0F">
-                <node concept="2c44te" id="7Ja64GBdQEU" role="lGtFl">
-                  <node concept="1Z$b5t" id="7Ja64GBdQEV" role="2c44t1">
-                    <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
-                  </node>
-                </node>
-              </node>
-              <node concept="10Oyi0" id="7Ja64GBdR9R" role="1ajw0F" />
-              <node concept="10P_77" id="34jUqC_VR5D" role="1ajl9A" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1Z5TYs" id="hwyZxSY" role="3cqZAp">
-        <node concept="mw_s8" id="hwyZRij" role="1ZfhKB">
-          <node concept="2c44tf" id="hwyZRik" role="mwGJk">
-            <node concept="A3Dl8" id="hwyZRB2" role="2c44tc">
-              <node concept="33vP2l" id="hwyZRB3" role="A3Ik2">
-                <node concept="2c44te" id="hwyZRRP" role="lGtFl">
-                  <node concept="1Z$b5t" id="hwyZS6_" role="2c44t1">
-                    <ref role="1Z$eMM" node="hwyZbXq" resolve="paramType" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="mw_s8" id="hwyZxT1" role="1ZfhK$">
-          <node concept="1Z2H0r" id="hwyZwPr" role="mwGJk">
-            <node concept="1YBJjd" id="hwyZxjd" role="1Z2MuG">
-              <ref role="1YBMHb" node="7Ja64GBdQEL" resolve="whereIdxOp" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1YaCAy" id="7Ja64GBdQEL" role="1YuTPh">
-      <property role="TrG5h" value="whereIdxOp" />
-      <ref role="1YaFvo" to="pkab:7Ja64GBdQxd" resolve="WhereWithIndexOperation" />
-    </node>
-  </node>
   <node concept="1YbPZF" id="2oJmO5M4B3W">
     <property role="TrG5h" value="typeof_LetScopeFunctionOperation" />
     <property role="3GE5qa" value="scopeFunction" />
@@ -1115,6 +1118,31 @@
     <node concept="1YaCAy" id="2oJmO5M4B3Z" role="1YuTPh">
       <property role="TrG5h" value="letScopeFunctionOperation" />
       <ref role="1YaFvo" to="pkab:2oJmO5M0doW" resolve="LetScopeFunctionOperation" />
+    </node>
+  </node>
+  <node concept="3qnSWH" id="2OpC$gsKXzW">
+    <property role="TrG5h" value="substituteType_TypeAliasType" />
+    <property role="3GE5qa" value="typeAlias" />
+    <node concept="3clFbS" id="2OpC$gsKXzX" role="3hT0BD">
+      <node concept="3clFbF" id="2OpC$gsKXAs" role="3cqZAp">
+        <node concept="2OqwBi" id="2OpC$gsKYB_" role="3clFbG">
+          <node concept="2OqwBi" id="2OpC$gsKXQu" role="2Oq$k0">
+            <node concept="1YBJjd" id="2OpC$gsKXAr" role="2Oq$k0">
+              <ref role="1YBMHb" node="2OpC$gsKXzZ" resolve="typeAliasType" />
+            </node>
+            <node concept="3TrEf2" id="2OpC$gsKYdQ" role="2OqNvi">
+              <ref role="3Tt5mk" to="pkab:3FS0SfFPObY" resolve="typeAliasDeclaration" />
+            </node>
+          </node>
+          <node concept="3TrEf2" id="2OpC$gsKZog" role="2OqNvi">
+            <ref role="3Tt5mk" to="pkab:3FS0SfFP0YE" resolve="type" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="2OpC$gsKXzZ" role="1YuTPh">
+      <property role="TrG5h" value="typeAliasType" />
+      <ref role="1YaFvo" to="pkab:3FS0SfFPObX" resolve="TypeAliasType" />
     </node>
   </node>
   <node concept="1YbPZF" id="2oJmO5M48Z6">


### PR DESCRIPTION
## Name
`type alias`

## Operation Type
Class element.

## Use Case
The `type alias` can be used to define an alternative name for a type. Using the type alias is equivalent as using the referenced type.

## Comments

Example of usage.
```java
class C {
  type alias OptStr = Optional<string>;
  public void t() {
    OptStr opt = Optional.<string>ofNullable("test");
  }
  ...
}
```
