### PR TITLE
Add 'getOrPut' operation for maps to the new base language extensions

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -9803,6 +9803,26 @@
               </node>
             </node>
           </node>
+          <node concept="1SiIV0" id="1B6xkzkaKkz" role="3bR37C">
+            <node concept="3bR9La" id="1B6xkzkaKk$" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+            </node>
+          </node>
+          <node concept="1SiIV0" id="1B6xkzkaKk_" role="3bR37C">
+            <node concept="3bR9La" id="1B6xkzkaKkA" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:7Kfy9QB6L0C" resolve="collections.runtime" />
+            </node>
+          </node>
+          <node concept="1SiIV0" id="1B6xkzkaKkB" role="3bR37C">
+            <node concept="3bR9La" id="1B6xkzkaKkC" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+            </node>
+          </node>
+          <node concept="1SiIV0" id="1B6xkzkaUCO" role="3bR37C">
+            <node concept="3bR9La" id="1B6xkzkaUCP" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:7YI57w6K09t" resolve="jetbrains.mps.baseLanguage.collections#1151699677197" />
+            </node>
+          </node>
         </node>
         <node concept="1E0d5M" id="vJfcQmbzfS" role="1E1XAP">
           <ref role="1E0d5P" node="vJfcQmbzfZ" resolve="de.itemis.mps.baseLanguageExtensions.runtime" />
@@ -9830,6 +9850,11 @@
         <node concept="1SiIV0" id="5IoIE_Gg3Xe" role="3bR37C">
           <node concept="1Busua" id="5IoIE_Gg3Xf" role="1SiIV1">
             <ref role="1Busuk" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1B6xkzkaKko" role="3bR37C">
+          <node concept="3bR9La" id="1B6xkzkaKkp" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
           </node>
         </node>
       </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
@@ -29,6 +29,9 @@
       <concept id="1153422105332" name="jetbrains.mps.baseLanguage.structure.RemExpression" flags="nn" index="2dk9JS" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1732176556423009631" name="jetbrains.mps.baseLanguage.structure.MultiLineComment" flags="ng" index="2lOVwT">
+        <child id="1732176556423038857" name="lines" index="2lOMFJ" />
+      </concept>
       <concept id="1224500799915" name="jetbrains.mps.baseLanguage.structure.BitwiseXorExpression" flags="nn" index="pVQyQ" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <property id="2523873803623706117" name="isMultiline" index="hSjvv" />
@@ -143,6 +146,10 @@
       <concept id="7915817776605258993" name="de.itemis.mps.baseLanguageExtensions.structure.SelectWithIndexOperation" flags="ng" index="2kBsqy" />
       <concept id="5842252078326680676" name="de.itemis.mps.baseLanguageExtensions.structure.GroupByOperation" flags="ng" index="2pSdkF" />
       <concept id="7488777117048605758" name="de.itemis.mps.baseLanguageExtensions.structure.ZipOperation" flags="ng" index="Kbfsy" />
+      <concept id="3671075362123813704" name="de.itemis.mps.baseLanguageExtensions.structure.GetOrComputeOperation" flags="ng" index="15T_jv">
+        <child id="3671075362123813706" name="key" index="15T_jt" />
+        <child id="3671075362123813705" name="closure" index="15T_ju" />
+      </concept>
       <concept id="2751518233990321717" name="de.itemis.mps.baseLanguageExtensions.structure.ScopeFunctionOperation" flags="ng" index="1kbSPO">
         <child id="2751518233990321719" name="closure" index="1kbSPQ" />
       </concept>
@@ -1856,7 +1863,7 @@
               <property role="3oM_SC" value="list" />
             </node>
             <node concept="3oM_SD" id="7deuf6J8dpW" role="1PaTwD">
-              <property role="3oM_SC" value="a" />
+              <property role="3oM_SC" value="as" />
             </node>
             <node concept="3oM_SD" id="7deuf6J8dqt" role="1PaTwD">
               <property role="3oM_SC" value="the" />
@@ -2082,6 +2089,248 @@
             </node>
             <node concept="3oM_SD" id="7deuf6J8bOo" role="1PaTwD">
               <property role="3oM_SC" value="3]]" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3bMhTtR6R8O" role="3cqZAp" />
+        <node concept="2lOVwT" id="7kYXsDnhwcm" role="3cqZAp">
+          <node concept="1PaTwC" id="7kYXsDnhwcn" role="2lOMFJ">
+            <node concept="3oM_SD" id="7kYXsDnhxdt" role="1PaTwD">
+              <property role="3oM_SC" value="Upon" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhxk4" role="1PaTwD">
+              <property role="3oM_SC" value="repeated" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhxsp" role="1PaTwD">
+              <property role="3oM_SC" value="request" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhxGO" role="1PaTwD">
+              <property role="3oM_SC" value="we" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhxOV" role="1PaTwD">
+              <property role="3oM_SC" value="also" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhxXg" role="1PaTwD">
+              <property role="3oM_SC" value="offer" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhy5_" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhy5A" role="1PaTwD">
+              <property role="3oM_SC" value="same" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhy5B" role="1PaTwD">
+              <property role="3oM_SC" value="functionality" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhymg" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhyun" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhyAu" role="1PaTwD">
+              <property role="3oM_SC" value="more" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhyH5" role="1PaTwD">
+              <property role="3oM_SC" value="&quot;Java-esk&quot;" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnh$55" role="1PaTwD">
+              <property role="3oM_SC" value="style" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnh$dc" role="1PaTwD">
+              <property role="3oM_SC" value="that" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnh$lj" role="1PaTwD">
+              <property role="3oM_SC" value="looks" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnh$lk" role="1PaTwD">
+              <property role="3oM_SC" value="more" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnh$ll" role="1PaTwD">
+              <property role="3oM_SC" value="like" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnh$ts" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnh$tt" role="1PaTwD">
+              <property role="3oM_SC" value="method" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnh$_M" role="1PaTwD">
+              <property role="3oM_SC" value="call" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnh$I7" role="1PaTwD">
+              <property role="3oM_SC" value="we" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnh$I8" role="1PaTwD">
+              <property role="3oM_SC" value="actually" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnhW1H" role="1PaTwD">
+              <property role="3oM_SC" value="augment" />
+            </node>
+            <node concept="3oM_SD" id="7kYXsDnh$YL" role="1PaTwD">
+              <property role="3oM_SC" value="anyway" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7kYXsDnef0v" role="3cqZAp">
+          <node concept="2OqwBi" id="7kYXsDneftW" role="3clFbG">
+            <node concept="37vLTw" id="7kYXsDnef0t" role="2Oq$k0">
+              <ref role="3cqZAo" node="7deuf6J7LQT" resolve="m" />
+            </node>
+            <node concept="15T_jv" id="7kYXsDnegjJ" role="2OqNvi">
+              <node concept="1bVj0M" id="7kYXsDnegjK" role="15T_ju">
+                <node concept="37vLTG" id="7kYXsDnmEtm" role="1bW2Oz">
+                  <property role="TrG5h" value="key" />
+                  <node concept="17QB3L" id="7kYXsDnmEIb" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="7kYXsDnegjN" role="1bW5cS">
+                  <node concept="3clFbF" id="7kYXsDnhBoZ" role="3cqZAp">
+                    <node concept="2ShNRf" id="7kYXsDnm$hv" role="3clFbG">
+                      <node concept="Tc6Ow" id="7kYXsDnm_cR" role="2ShVmc">
+                        <node concept="10Oyi0" id="7kYXsDnmCoc" role="HW$YZ" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="7kYXsDnhZmL" role="15T_jt">
+                <property role="Xl_RC" value="" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7kYXsDnhZ0$" role="3cqZAp">
+          <node concept="2OqwBi" id="7kYXsDnhZ0_" role="3clFbG">
+            <node concept="37vLTw" id="7kYXsDnhZ0A" role="2Oq$k0">
+              <ref role="3cqZAo" node="7deuf6J7LQT" resolve="m" />
+            </node>
+            <node concept="15T_jv" id="7kYXsDnhZ0B" role="2OqNvi">
+              <node concept="1bVj0M" id="7kYXsDnhZ0C" role="15T_ju">
+                <node concept="37vLTG" id="7kYXsDnmF4F" role="1bW2Oz">
+                  <property role="TrG5h" value="key" />
+                  <node concept="17QB3L" id="7kYXsDnmF4G" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="7kYXsDnhZ0F" role="1bW5cS">
+                  <node concept="3clFbF" id="7kYXsDnhZ0G" role="3cqZAp">
+                    <node concept="2ShNRf" id="7kYXsDnmyWs" role="3clFbG">
+                      <node concept="Tc6Ow" id="7kYXsDnmzPf" role="2ShVmc">
+                        <node concept="10Oyi0" id="7kYXsDnmCXa" role="HW$YZ" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="7kYXsDnkJal" role="15T_jt">
+                <property role="Xl_RC" value="" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7kYXsDnhXe1" role="3cqZAp">
+          <node concept="2OqwBi" id="7kYXsDnhXHp" role="3clFbG">
+            <node concept="37vLTw" id="7kYXsDnhXdZ" role="2Oq$k0">
+              <ref role="3cqZAo" node="4OYzberaCy_" resolve="map" />
+            </node>
+            <node concept="15T_jv" id="7kYXsDnhYow" role="2OqNvi">
+              <node concept="1bVj0M" id="7kYXsDnhYox" role="15T_ju">
+                <node concept="37vLTG" id="7kYXsDnmFfI" role="1bW2Oz">
+                  <property role="TrG5h" value="key" />
+                  <node concept="17QB3L" id="7kYXsDnmFfJ" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="7kYXsDnhYo$" role="1bW5cS">
+                  <node concept="3clFbF" id="7kYXsDnhYG7" role="3cqZAp">
+                    <node concept="3cmrfG" id="7kYXsDnhYG6" role="3clFbG">
+                      <property role="3cmrfH" value="4" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="7kYXsDnhYya" role="15T_jt">
+                <property role="Xl_RC" value="" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7kYXsDnj0Yw" role="3cqZAp">
+          <node concept="3cpWsn" id="7kYXsDnj0Yx" role="3cpWs9">
+            <property role="TrG5h" value="map_int_int" />
+            <node concept="3rvAFt" id="7kYXsDnj02q" role="1tU5fm">
+              <node concept="10Oyi0" id="7kYXsDnj02v" role="3rvQeY" />
+              <node concept="10Oyi0" id="7kYXsDnj02w" role="3rvSg0" />
+            </node>
+            <node concept="2ShNRf" id="7kYXsDnj0Yy" role="33vP2m">
+              <node concept="3rGOSV" id="7kYXsDnj0Yz" role="2ShVmc">
+                <node concept="10Oyi0" id="7kYXsDnj0Y$" role="3rHrn6" />
+                <node concept="10Oyi0" id="7kYXsDnj0Y_" role="3rHtpV" />
+                <node concept="3Mi1_Z" id="7kYXsDnj0YA" role="3Mj9YC">
+                  <node concept="3Milgn" id="7kYXsDnj0YB" role="3MiYds">
+                    <node concept="3cmrfG" id="7kYXsDnj0YC" role="3MiK7k">
+                      <property role="3cmrfH" value="4" />
+                    </node>
+                    <node concept="3cmrfG" id="7kYXsDnj0YD" role="3MiMdn">
+                      <property role="3cmrfH" value="4" />
+                    </node>
+                  </node>
+                  <node concept="3Milgn" id="7kYXsDnj0YE" role="3MiYds">
+                    <node concept="3cmrfG" id="7kYXsDnj0YF" role="3MiK7k">
+                      <property role="3cmrfH" value="5" />
+                    </node>
+                    <node concept="3cmrfG" id="7kYXsDnj0YG" role="3MiMdn">
+                      <property role="3cmrfH" value="4" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7kYXsDnj1tL" role="3cqZAp">
+          <node concept="2OqwBi" id="7kYXsDnj1YC" role="3clFbG">
+            <node concept="37vLTw" id="7kYXsDnj1tJ" role="2Oq$k0">
+              <ref role="3cqZAo" node="7kYXsDnj0Yx" resolve="map_int_int" />
+            </node>
+            <node concept="15T_jv" id="7kYXsDnj3xe" role="2OqNvi">
+              <node concept="1bVj0M" id="7kYXsDnj3xf" role="15T_ju">
+                <node concept="37vLTG" id="7kYXsDnkIxz" role="1bW2Oz">
+                  <property role="TrG5h" value="key" />
+                  <node concept="10Oyi0" id="7kYXsDnkIQb" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="7kYXsDnj3xi" role="1bW5cS">
+                  <node concept="3clFbF" id="7kYXsDnj3Pn" role="3cqZAp">
+                    <node concept="3cmrfG" id="7kYXsDnj3Pm" role="3clFbG">
+                      <property role="3cmrfH" value="9" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cmrfG" id="7kYXsDnj3F8" role="15T_jt">
+                <property role="3cmrfH" value="42" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7kYXsDnmt_2" role="3cqZAp">
+          <node concept="2OqwBi" id="7kYXsDnmu5C" role="3clFbG">
+            <node concept="37vLTw" id="7kYXsDnmt_0" role="2Oq$k0">
+              <ref role="3cqZAo" node="7kYXsDnj0Yx" resolve="map_int_int" />
+            </node>
+            <node concept="15T_jv" id="7kYXsDnmuKL" role="2OqNvi">
+              <node concept="1bVj0M" id="7kYXsDnmuKM" role="15T_ju">
+                <node concept="37vLTG" id="7kYXsDnmuKN" role="1bW2Oz">
+                  <property role="TrG5h" value="key" />
+                  <node concept="10Oyi0" id="7kYXsDnmyhq" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="7kYXsDnmuKO" role="1bW5cS">
+                  <node concept="3clFbF" id="7kYXsDnmysQ" role="3cqZAp">
+                    <node concept="3cmrfG" id="7kYXsDnmysP" role="3clFbG">
+                      <property role="3cmrfH" value="5" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cmrfG" id="7kYXsDnmxgd" role="15T_jt">
+                <property role="3cmrfH" value="42" />
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
@@ -176,6 +176,9 @@
       <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
         <child id="1176906787974" name="rightExpression" index="576Qk" />
       </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
       <concept id="1172664342967" name="jetbrains.mps.baseLanguage.collections.structure.TakeOperation" flags="nn" index="8ftyA">
         <child id="1172664372046" name="elementsToTake" index="8f$Dv" />
       </concept>
@@ -191,6 +194,7 @@
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
         <child id="1197683466920" name="keyType" index="3rvQeY" />
@@ -199,6 +203,7 @@
       <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
         <child id="1197687026896" name="keyType" index="3rHrn6" />
         <child id="1197687035757" name="valueType" index="3rHtpV" />
+        <child id="1206655950512" name="initializer" index="3Mj9YC" />
       </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
@@ -209,6 +214,13 @@
       <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
         <child id="1197932505799" name="map" index="3ElQJh" />
         <child id="1197932525128" name="key" index="3ElVtu" />
+      </concept>
+      <concept id="1206655653991" name="jetbrains.mps.baseLanguage.collections.structure.MapInitializer" flags="ng" index="3Mi1_Z">
+        <child id="1206655902276" name="entries" index="3MiYds" />
+      </concept>
+      <concept id="1206655735055" name="jetbrains.mps.baseLanguage.collections.structure.MapEntry" flags="ng" index="3Milgn">
+        <child id="1206655844556" name="key" index="3MiK7k" />
+        <child id="1206655853135" name="value" index="3MiMdn" />
       </concept>
     </language>
   </registry>
@@ -1813,6 +1825,263 @@
                   <node concept="17QB3L" id="1$qgNbtg7x8" role="1tU5fm" />
                 </node>
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7deuf6J86se" role="3cqZAp" />
+        <node concept="3SKdUt" id="7deuf6J87LD" role="3cqZAp">
+          <node concept="1PaTwC" id="7deuf6J87LE" role="1aUNEU">
+            <node concept="3oM_SD" id="7deuf6J87VG" role="1PaTwD">
+              <property role="3oM_SC" value="adding" />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J87VH" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J87VI" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J87VJ" role="1PaTwD">
+              <property role="3oM_SC" value="map" />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J87VK" role="1PaTwD">
+              <property role="3oM_SC" value="that" />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J87VL" role="1PaTwD">
+              <property role="3oM_SC" value="has" />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J87VM" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8dpF" role="1PaTwD">
+              <property role="3oM_SC" value="list" />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8dpW" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8dqt" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8dqu" role="1PaTwD">
+              <property role="3oM_SC" value="value" />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8dqv" role="1PaTwD">
+              <property role="3oM_SC" value="type" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7deuf6J7LQQ" role="3cqZAp">
+          <node concept="3cpWsn" id="7deuf6J7LQT" role="3cpWs9">
+            <property role="TrG5h" value="m" />
+            <node concept="3rvAFt" id="7deuf6J7LQK" role="1tU5fm">
+              <node concept="17QB3L" id="7deuf6J7LXd" role="3rvQeY" />
+              <node concept="_YKpA" id="7deuf6J7M31" role="3rvSg0">
+                <node concept="10Oyi0" id="7deuf6J7M8U" role="_ZDj9" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7deuf6J7NcY" role="33vP2m">
+              <node concept="3rGOSV" id="7deuf6J7NcE" role="2ShVmc">
+                <node concept="17QB3L" id="7deuf6J7NcF" role="3rHrn6" />
+                <node concept="_YKpA" id="7deuf6J7NcG" role="3rHtpV">
+                  <node concept="10Oyi0" id="7deuf6J7NcH" role="_ZDj9" />
+                </node>
+                <node concept="3Mi1_Z" id="7deuf6J7TRQ" role="3Mj9YC">
+                  <node concept="3Milgn" id="7deuf6J7U2N" role="3MiYds">
+                    <node concept="Xl_RD" id="7deuf6J7U8C" role="3MiK7k">
+                      <property role="Xl_RC" value="one" />
+                    </node>
+                    <node concept="2ShNRf" id="7deuf6J7Ukb" role="3MiMdn">
+                      <node concept="Tc6Ow" id="7deuf6J7Uv1" role="2ShVmc">
+                        <node concept="10Oyi0" id="7deuf6J7V6M" role="HW$YZ" />
+                        <node concept="3cmrfG" id="7deuf6J7Vo0" role="HW$Y0">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3Milgn" id="7deuf6J7VtW" role="3MiYds">
+                    <node concept="Xl_RD" id="7deuf6J7VtX" role="3MiK7k">
+                      <property role="Xl_RC" value="two" />
+                    </node>
+                    <node concept="2ShNRf" id="7deuf6J7VtY" role="3MiMdn">
+                      <node concept="Tc6Ow" id="7deuf6J7VtZ" role="2ShVmc">
+                        <node concept="10Oyi0" id="7deuf6J7Vu0" role="HW$YZ" />
+                        <node concept="3cmrfG" id="7deuf6J7Xw6" role="HW$Y0">
+                          <property role="3cmrfH" value="2" />
+                        </node>
+                        <node concept="3cmrfG" id="7deuf6J7XAb" role="HW$Y0">
+                          <property role="3cmrfH" value="2" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3Milgn" id="7deuf6J7XGc" role="3MiYds">
+                    <node concept="Xl_RD" id="7deuf6J7XGd" role="3MiK7k">
+                      <property role="Xl_RC" value="three" />
+                    </node>
+                    <node concept="2ShNRf" id="7deuf6J7XGe" role="3MiMdn">
+                      <node concept="Tc6Ow" id="7deuf6J7XGf" role="2ShVmc">
+                        <node concept="10Oyi0" id="7deuf6J7XGg" role="HW$YZ" />
+                        <node concept="3cmrfG" id="7deuf6J7XGi" role="HW$Y0">
+                          <property role="3cmrfH" value="3" />
+                        </node>
+                        <node concept="3cmrfG" id="7deuf6J7XY9" role="HW$Y0">
+                          <property role="3cmrfH" value="3" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7deuf6J85wS" role="3cqZAp" />
+        <node concept="3clFbF" id="7deuf6J80TT" role="3cqZAp">
+          <node concept="2OqwBi" id="7deuf6J8494" role="3clFbG">
+            <node concept="3EllGN" id="7deuf6J81r7" role="2Oq$k0">
+              <node concept="Xl_RD" id="7deuf6J81DG" role="3ElVtu">
+                <property role="Xl_RC" value="three" />
+              </node>
+              <node concept="37vLTw" id="7deuf6J80TR" role="3ElQJh">
+                <ref role="3cqZAo" node="7deuf6J7LQT" resolve="m" />
+              </node>
+            </node>
+            <node concept="TSZUe" id="7deuf6J855w" role="2OqNvi">
+              <node concept="3cmrfG" id="7deuf6J85d3" role="25WWJ7">
+                <property role="3cmrfH" value="3" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7deuf6J7NjV" role="3cqZAp" />
+        <node concept="3clFbF" id="7deuf6J7Nwl" role="3cqZAp">
+          <node concept="2OqwBi" id="7deuf6J7SIZ" role="3clFbG">
+            <node concept="3m5q9F" id="7deuf6J7Ogu" role="2Oq$k0">
+              <node concept="Xl_RD" id="7deuf6J7OpJ" role="3ElVtu">
+                <property role="Xl_RC" value="four" />
+              </node>
+              <node concept="37vLTw" id="7deuf6J7Nwj" role="3ElQJh">
+                <ref role="3cqZAo" node="7deuf6J7LQT" resolve="m" />
+              </node>
+              <node concept="1bVj0M" id="7deuf6J7OgA" role="3m5q9D">
+                <node concept="3clFbS" id="7deuf6J7OgC" role="1bW5cS">
+                  <node concept="3clFbF" id="7deuf6J7ODc" role="3cqZAp">
+                    <node concept="2ShNRf" id="7deuf6J7ODa" role="3clFbG">
+                      <node concept="Tc6Ow" id="7deuf6J7Q8x" role="2ShVmc">
+                        <node concept="10Oyi0" id="7deuf6J7RaH" role="HW$YZ" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTG" id="7deuf6J7OgE" role="1bW2Oz">
+                  <property role="TrG5h" value="key" />
+                  <node concept="17QB3L" id="7deuf6J7OgG" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+            <node concept="TSZUe" id="7deuf6J7TeH" role="2OqNvi">
+              <node concept="3cmrfG" id="7deuf6J7YJK" role="25WWJ7">
+                <property role="3cmrfH" value="4" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7deuf6J7YZw" role="3cqZAp">
+          <node concept="2OqwBi" id="7deuf6J7YZx" role="3clFbG">
+            <node concept="3EllGN" id="7deuf6J7Z_i" role="2Oq$k0">
+              <node concept="37vLTw" id="7deuf6J7YZ$" role="3ElQJh">
+                <ref role="3cqZAo" node="7deuf6J7LQT" resolve="m" />
+              </node>
+              <node concept="Xl_RD" id="7deuf6J7YZz" role="3ElVtu">
+                <property role="Xl_RC" value="four" />
+              </node>
+            </node>
+            <node concept="TSZUe" id="7deuf6J7YZH" role="2OqNvi">
+              <node concept="3cmrfG" id="7deuf6J7YZI" role="25WWJ7">
+                <property role="3cmrfH" value="4" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7deuf6J7ZbL" role="3cqZAp">
+          <node concept="2OqwBi" id="7deuf6J7ZbM" role="3clFbG">
+            <node concept="3EllGN" id="7deuf6J7ZIw" role="2Oq$k0">
+              <node concept="37vLTw" id="7deuf6J7ZbP" role="3ElQJh">
+                <ref role="3cqZAo" node="7deuf6J7LQT" resolve="m" />
+              </node>
+              <node concept="Xl_RD" id="7deuf6J7ZbO" role="3ElVtu">
+                <property role="Xl_RC" value="four" />
+              </node>
+            </node>
+            <node concept="TSZUe" id="7deuf6J7ZbY" role="2OqNvi">
+              <node concept="3cmrfG" id="7deuf6J7ZbZ" role="25WWJ7">
+                <property role="3cmrfH" value="4" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7deuf6J7Zc0" role="3cqZAp">
+          <node concept="2OqwBi" id="7deuf6J7Zc1" role="3clFbG">
+            <node concept="3EllGN" id="7deuf6J7ZS0" role="2Oq$k0">
+              <node concept="37vLTw" id="7deuf6J7Zc4" role="3ElQJh">
+                <ref role="3cqZAo" node="7deuf6J7LQT" resolve="m" />
+              </node>
+              <node concept="Xl_RD" id="7deuf6J7Zc3" role="3ElVtu">
+                <property role="Xl_RC" value="four" />
+              </node>
+            </node>
+            <node concept="TSZUe" id="7deuf6J7Zcd" role="2OqNvi">
+              <node concept="3cmrfG" id="7deuf6J7Zce" role="25WWJ7">
+                <property role="3cmrfH" value="4" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7deuf6J8cHN" role="3cqZAp">
+          <node concept="2OqwBi" id="7deuf6J8cHK" role="3clFbG">
+            <node concept="10M0yZ" id="7deuf6J8cHL" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" />
+            </node>
+            <node concept="liA8E" id="7deuf6J8cHM" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.Object)" resolve="println" />
+              <node concept="37vLTw" id="7deuf6J8cP7" role="37wK5m">
+                <ref role="3cqZAo" node="7deuf6J7LQT" resolve="m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="7deuf6J8bHN" role="3cqZAp">
+          <node concept="1PaTwC" id="7deuf6J8bHO" role="1aUNEU">
+            <node concept="3oM_SD" id="7deuf6J8bOd" role="1PaTwD">
+              <property role="3oM_SC" value="[four=[4," />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8bOe" role="1PaTwD">
+              <property role="3oM_SC" value="4," />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8bOf" role="1PaTwD">
+              <property role="3oM_SC" value="4," />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8bOg" role="1PaTwD">
+              <property role="3oM_SC" value="4]," />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8bOj" role="1PaTwD">
+              <property role="3oM_SC" value="one=[1]," />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8bOk" role="1PaTwD">
+              <property role="3oM_SC" value="two=[2," />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8bOl" role="1PaTwD">
+              <property role="3oM_SC" value="2]," />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8bOm" role="1PaTwD">
+              <property role="3oM_SC" value="three=[3," />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8bOn" role="1PaTwD">
+              <property role="3oM_SC" value="3," />
+            </node>
+            <node concept="3oM_SD" id="7deuf6J8bOo" role="1PaTwD">
+              <property role="3oM_SC" value="3]]" />
             </node>
           </node>
         </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
@@ -22,6 +22,10 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="1153422105332" name="jetbrains.mps.baseLanguage.structure.RemExpression" flags="nn" index="2dk9JS" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
@@ -50,6 +54,7 @@
       </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
@@ -57,6 +62,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271484915" name="jetbrains.mps.baseLanguage.structure.SubstringExpression" flags="nn" index="17RM3I">
         <child id="1225271484917" name="startIndex" index="17RM3C" />
@@ -142,6 +148,9 @@
       </concept>
       <concept id="2751518233990321721" name="de.itemis.mps.baseLanguageExtensions.structure.ApplyScopeFunctionOperation" flags="ng" index="1kbSPS" />
       <concept id="2751518233990321724" name="de.itemis.mps.baseLanguageExtensions.structure.LetScopeFunctionOperation" flags="ng" index="1kbSPX" />
+      <concept id="5566040892506844888" name="de.itemis.mps.baseLanguageExtensions.structure.MapElementOrCompute" flags="ng" index="3m5q9F">
+        <child id="5566040892506844890" name="closure" index="3m5q9D" />
+      </concept>
       <concept id="5566040892496752333" name="de.itemis.mps.baseLanguageExtensions.structure.SmartAtomicClosureParameterDeclaration" flags="ig" index="3nFU9Y" />
       <concept id="8919968723020343837" name="de.itemis.mps.baseLanguageExtensions.structure.ForEachWithIndexOperation" flags="ng" index="1sWJ9m" />
       <concept id="8919968723020245069" name="de.itemis.mps.baseLanguageExtensions.structure.WhereWithIndexOperation" flags="ng" index="1sZn06" />
@@ -186,6 +195,10 @@
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
         <child id="1197683466920" name="keyType" index="3rvQeY" />
         <child id="1197683475734" name="valueType" index="3rvSg0" />
+      </concept>
+      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
+        <child id="1197687026896" name="keyType" index="3rHrn6" />
+        <child id="1197687035757" name="valueType" index="3rHtpV" />
       </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
@@ -1586,6 +1599,228 @@
       <node concept="3cqZAl" id="2oJmO5M1vRm" role="3clF45" />
     </node>
     <node concept="3Tm1VV" id="2oJmO5M1vQd" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="4OYzberaCvu">
+    <property role="TrG5h" value="MapGetOrPutSandbox" />
+    <node concept="2YIFZL" id="4OYzberaCxx" role="jymVt">
+      <property role="TrG5h" value="usage" />
+      <node concept="3clFbS" id="4OYzberaCx$" role="3clF47">
+        <node concept="3cpWs8" id="4OYzberaEJh" role="3cqZAp">
+          <node concept="3cpWsn" id="4OYzberaEJk" role="3cpWs9">
+            <property role="TrG5h" value="key" />
+            <property role="3TUv4t" value="true" />
+            <node concept="17QB3L" id="4OYzberaEJf" role="1tU5fm" />
+            <node concept="Xl_RD" id="4OYzberaEL6" role="33vP2m">
+              <property role="Xl_RC" value="key" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4OYzberaCyy" role="3cqZAp">
+          <node concept="3cpWsn" id="4OYzberaCy_" role="3cpWs9">
+            <property role="TrG5h" value="map" />
+            <node concept="3rvAFt" id="4OYzberaCyv" role="1tU5fm">
+              <node concept="17QB3L" id="4OYzberaCza" role="3rvQeY" />
+              <node concept="10Oyi0" id="4OYzberaCzJ" role="3rvSg0" />
+            </node>
+            <node concept="2ShNRf" id="4OYzberaCAI" role="33vP2m">
+              <node concept="3rGOSV" id="4OYzberaD2Q" role="2ShVmc">
+                <node concept="17QB3L" id="4OYzberaDaN" role="3rHrn6" />
+                <node concept="10Oyi0" id="4OYzberaDfw" role="3rHtpV" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4OYzberaDgR" role="3cqZAp" />
+        <node concept="3SKdUt" id="4OYzberaEkI" role="3cqZAp">
+          <node concept="1PaTwC" id="4OYzberaEkJ" role="1aUNEU">
+            <node concept="3oM_SD" id="4OYzberaElf" role="1PaTwD">
+              <property role="3oM_SC" value="normal" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaElg" role="1PaTwD">
+              <property role="3oM_SC" value="element" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaElh" role="1PaTwD">
+              <property role="3oM_SC" value="put/update" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4OYzberaEmj" role="3cqZAp">
+          <node concept="37vLTI" id="4OYzberaFYf" role="3clFbG">
+            <node concept="3cmrfG" id="4OYzberaFYZ" role="37vLTx">
+              <property role="3cmrfH" value="42" />
+            </node>
+            <node concept="3EllGN" id="4OYzberaEGY" role="37vLTJ">
+              <node concept="37vLTw" id="4OYzberaEXU" role="3ElVtu">
+                <ref role="3cqZAo" node="4OYzberaEJk" resolve="key" />
+              </node>
+              <node concept="37vLTw" id="4OYzberaEmh" role="3ElQJh">
+                <ref role="3cqZAo" node="4OYzberaCy_" resolve="map" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4OYzberaEjy" role="3cqZAp" />
+        <node concept="3SKdUt" id="4OYzberaDhZ" role="3cqZAp">
+          <node concept="1PaTwC" id="4OYzberaDi0" role="1aUNEU">
+            <node concept="3oM_SD" id="4OYzberaDiu" role="1PaTwD">
+              <property role="3oM_SC" value="normal" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaDiv" role="1PaTwD">
+              <property role="3oM_SC" value="element" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaDiw" role="1PaTwD">
+              <property role="3oM_SC" value="access" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4OYzberaGis" role="3cqZAp">
+          <node concept="2OqwBi" id="4OYzberaGKo" role="3clFbG">
+            <node concept="10M0yZ" id="4OYzberaGj0" role="2Oq$k0">
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+            </node>
+            <node concept="liA8E" id="4OYzberaH0p" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(int)" resolve="println" />
+              <node concept="3EllGN" id="4OYzberaEgX" role="37wK5m">
+                <node concept="37vLTw" id="4OYzberaGeP" role="3ElVtu">
+                  <ref role="3cqZAo" node="4OYzberaEJk" resolve="key" />
+                </node>
+                <node concept="37vLTw" id="4OYzberaEgZ" role="3ElQJh">
+                  <ref role="3cqZAo" node="4OYzberaCy_" resolve="map" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4OYzberaEiA" role="3cqZAp" />
+        <node concept="3SKdUt" id="4OYzberaHR9" role="3cqZAp">
+          <node concept="1PaTwC" id="4OYzberaHRa" role="1aUNEU">
+            <node concept="3oM_SD" id="4OYzberaIEM" role="1PaTwD">
+              <property role="3oM_SC" value="advanced" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaIEN" role="1PaTwD">
+              <property role="3oM_SC" value="element" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaIEO" role="1PaTwD">
+              <property role="3oM_SC" value="access" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaIEP" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaIEQ" role="1PaTwD">
+              <property role="3oM_SC" value="fallback" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaIER" role="1PaTwD">
+              <property role="3oM_SC" value="value" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaIES" role="1PaTwD">
+              <property role="3oM_SC" value="generator" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4OYzberaJuw" role="3cqZAp">
+          <node concept="2OqwBi" id="4OYzberaJuy" role="3clFbG">
+            <node concept="10M0yZ" id="4OYzberaJuz" role="2Oq$k0">
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+            </node>
+            <node concept="liA8E" id="4OYzberaJu$" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(int)" resolve="println" />
+              <node concept="3m5q9F" id="5qYvgS585Zt" role="37wK5m">
+                <node concept="37vLTw" id="4OYzberaJuB" role="3ElQJh">
+                  <ref role="3cqZAo" node="4OYzberaCy_" resolve="map" />
+                </node>
+                <node concept="37vLTw" id="4OYzberd4KX" role="3ElVtu">
+                  <ref role="3cqZAo" node="4OYzberaEJk" resolve="key" />
+                </node>
+                <node concept="1bVj0M" id="5qYvgS585Zu" role="3m5q9D">
+                  <node concept="3clFbS" id="5qYvgS585Zv" role="1bW5cS">
+                    <node concept="3clFbF" id="5qYvgS586c2" role="3cqZAp">
+                      <node concept="3cmrfG" id="5qYvgS586c1" role="3clFbG">
+                        <property role="3cmrfH" value="42" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTG" id="5qYvgS585Zw" role="1bW2Oz">
+                    <property role="TrG5h" value="key" />
+                    <node concept="17QB3L" id="5qYvgS58650" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4OYzberaIEU" role="3cqZAp" />
+        <node concept="3SKdUt" id="4OYzberaKp7" role="3cqZAp">
+          <node concept="1PaTwC" id="4OYzberaKp8" role="1aUNEU">
+            <node concept="3oM_SD" id="4OYzberaKt4" role="1PaTwD">
+              <property role="3oM_SC" value="somewhat" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaKt5" role="1PaTwD">
+              <property role="3oM_SC" value="useless" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaKt6" role="1PaTwD">
+              <property role="3oM_SC" value="element" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaKt7" role="1PaTwD">
+              <property role="3oM_SC" value="put/update" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaKt8" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaKt9" role="1PaTwD">
+              <property role="3oM_SC" value="fallback," />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaKta" role="1PaTwD">
+              <property role="3oM_SC" value="which" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaKtb" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaKtc" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberd7Po" role="1PaTwD">
+              <property role="3oM_SC" value="actually" />
+            </node>
+            <node concept="3oM_SD" id="4OYzberaKtd" role="1PaTwD">
+              <property role="3oM_SC" value="invoked" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4OYzberaKNP" role="3cqZAp">
+          <node concept="37vLTI" id="4OYzberaMw3" role="3clFbG">
+            <node concept="3cmrfG" id="4OYzberaMyf" role="37vLTx">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="3m5q9F" id="1$qgNbtg7io" role="37vLTJ">
+              <node concept="37vLTw" id="4OYzberaKNN" role="3ElQJh">
+                <ref role="3cqZAo" node="4OYzberaCy_" resolve="map" />
+              </node>
+              <node concept="37vLTw" id="4OYzberd7z5" role="3ElVtu">
+                <ref role="3cqZAo" node="4OYzberaEJk" resolve="key" />
+              </node>
+              <node concept="1bVj0M" id="1$qgNbtg7ip" role="3m5q9D">
+                <node concept="3clFbS" id="1$qgNbtg7iq" role="1bW5cS">
+                  <node concept="3clFbF" id="1$qgNbtg7CM" role="3cqZAp">
+                    <node concept="3cmrfG" id="1$qgNbtg7CL" role="3clFbG">
+                      <property role="3cmrfH" value="23" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTG" id="1$qgNbtg7ir" role="1bW2Oz">
+                  <property role="TrG5h" value="key" />
+                  <node concept="17QB3L" id="1$qgNbtg7x8" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4OYzberaCx1" role="1B3o_S" />
+      <node concept="3cqZAl" id="4OYzberaCxn" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="4OYzberaCvv" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/de.itemis.mps.baseLanguageExtensions.mpl
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/de.itemis.mps.baseLanguageExtensions.mpl
@@ -24,6 +24,12 @@
         </facet>
       </facets>
       <external-templates />
+      <dependencies>
+        <dependency reexport="false">9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)</dependency>
+        <dependency reexport="false">5f9babc9-8d5d-4825-8e61-17b241ee6272(jetbrains.mps.baseLanguage.collections#1151699677197)</dependency>
+        <dependency reexport="false">83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)</dependency>
+        <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+      </dependencies>
       <languageVersions>
         <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
         <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
@@ -49,12 +55,14 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
         <module reference="52b771c2-b79f-4f44-98f2-d24fd25a210b(de.itemis.mps.baseLanguageExtensions)" version="0" />
         <module reference="0c2a16a3-4205-4401-a2b4-4af76e67fa52(de.itemis.mps.baseLanguageExtensions.generator)" version="0" />
         <module reference="d91eaf6f-a378-467f-9524-0c201ee2e15f(de.itemis.mps.baseLanguageExtensions.runtime)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
         <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+        <module reference="5f9babc9-8d5d-4825-8e61-17b241ee6272(jetbrains.mps.baseLanguage.collections#1151699677197)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
@@ -68,6 +76,7 @@
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false" scope="generate-into">fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)</dependency>
     <dependency reexport="false">83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)</dependency>
+    <dependency reexport="false">7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -75,6 +84,7 @@
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
@@ -87,14 +97,18 @@
     <language slang="l:3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7:jetbrains.mps.lang.context" version="0" />
     <language slang="l:ea3159bf-f48e-4720-bde2-86dba75f0d34:jetbrains.mps.lang.context.defs" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:7fa12e9c-b949-4976-b4fa-19accbc320b4:jetbrains.mps.lang.dataFlow" version="1" />
+    <language slang="l:97a52717-898f-4598-8150-573d9fd03868:jetbrains.mps.lang.dataFlow.analyzers" version="0" />
     <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:d7a92d38-f7db-40d0-8431-763b0c3c9f20:jetbrains.mps.lang.intentions" version="1" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
@@ -112,8 +126,13 @@
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
   <runtime>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
@@ -12,13 +12,24 @@
     <import index="96gm" ref="r:2eaed950-3bc1-47cd-9b02-e917ff994d7c(de.itemis.mps.baseLanguageExtensions.runtime)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="tp2g" ref="r:00000000-0000-4000-0000-011c89590334(jetbrains.mps.baseLanguage.closures.constraints)" />
-    <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" implicit="true" />
+    <import index="urs3" ref="r:fc76aa36-3cff-41c7-b94b-eee0e8341932(jetbrains.mps.internal.collections.runtime)" />
+    <import index="tp2r" ref="r:00000000-0000-4000-0000-011c8959032f(jetbrains.mps.baseLanguage.collections.generator.baseLanguage.template.main@generator)" />
+    <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="tp2c" ref="r:00000000-0000-4000-0000-011c89590338(jetbrains.mps.baseLanguage.closures.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="6038287468700811827" name="jetbrains.mps.baseLanguage.structure.GenericLValueExpression" flags="ng" index="2OlCL6">
+        <child id="8230959874503203826" name="type" index="auYmn" />
+        <child id="6900020712833426234" name="referenceExpression" index="2kxYXX" />
+        <child id="9101202990845387125" name="assignValueExression" index="sgxqj" />
+        <child id="6038287468700812034" name="getValueExpression" index="2OlCPR" />
+      </concept>
+      <concept id="6038287468700812090" name="jetbrains.mps.baseLanguage.structure.ValueRef" flags="ng" index="2OlCPf" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -30,6 +41,10 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -42,6 +57,9 @@
       </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -1009,6 +1027,188 @@
               <node concept="1mIQ4w" id="2oJmO5M57Bo" role="2OqNvi">
                 <node concept="chp4Y" id="2oJmO5M57Bp" role="cj9EA">
                   <ref role="cht4Q" to="pkab:2oJmO5M0doW" resolve="LetScopeFunctionOperation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="4OYzberkEy$" role="3acgRq">
+      <ref role="30HIoZ" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
+      <node concept="gft3U" id="4OYzberkG_c" role="1lVwrX">
+        <node concept="2OlCL6" id="4OYzberkG_g" role="gfFT$">
+          <node concept="3uibUv" id="I54NGztjeg" role="auYmn">
+            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            <node concept="29HgVG" id="I54NGztpTG" role="lGtFl">
+              <node concept="3NFfHV" id="I54NGztpTW" role="3NFExx">
+                <node concept="3clFbS" id="I54NGztpTX" role="2VODD2">
+                  <node concept="3clFbF" id="I54NGztpU6" role="3cqZAp">
+                    <node concept="1PxgMI" id="I54NGztqEF" role="3clFbG">
+                      <node concept="chp4Y" id="I54NGztqNl" role="3oSUPX">
+                        <ref role="cht4Q" to="tpee:fz3vP1H" resolve="Type" />
+                      </node>
+                      <node concept="2OqwBi" id="I54NGztq4_" role="1m5AlR">
+                        <node concept="30H73N" id="I54NGztpU5" role="2Oq$k0" />
+                        <node concept="3JvlWi" id="I54NGztqjp" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="I54NGztsvy" role="2kxYXX">
+            <node concept="1eOMI4" id="I54NGztqX0" role="2Oq$k0">
+              <node concept="10QFUN" id="I54NGztqX1" role="1eOMHV">
+                <node concept="10Nm6u" id="I54NGztsaP" role="10QFUP" />
+                <node concept="3uibUv" id="I54NGztqX3" role="10QFUM">
+                  <ref role="3uigEE" to="urs3:5Ffu4tBU$6H" resolve="IMapSequence" />
+                </node>
+              </node>
+              <node concept="1sPUBX" id="I54NGztqX4" role="lGtFl">
+                <ref role="v9R2y" to="tp2r:hwGFo3P" resolve="switch_sequence_operation_toSequence" />
+                <node concept="3NFfHV" id="I54NGztqX5" role="1sPUBK">
+                  <node concept="3clFbS" id="I54NGztqX6" role="2VODD2">
+                    <node concept="3clFbF" id="I54NGztqX7" role="3cqZAp">
+                      <node concept="2OqwBi" id="I54NGztqX8" role="3clFbG">
+                        <node concept="30H73N" id="I54NGztqX9" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="I54NGztqXa" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="I54NGztuo6" role="2OqNvi">
+              <ref role="37wK5l" to="urs3:I54NGzr4pR" resolve="getValueRef" />
+              <node concept="10Nm6u" id="I54NGztwJ9" role="37wK5m">
+                <node concept="29HgVG" id="I54NGztxwy" role="lGtFl">
+                  <node concept="3NFfHV" id="I54NGztxPL" role="3NFExx">
+                    <node concept="3clFbS" id="I54NGztxPM" role="2VODD2">
+                      <node concept="3clFbF" id="I54NGzty4h" role="3cqZAp">
+                        <node concept="2OqwBi" id="I54NGztyd3" role="3clFbG">
+                          <node concept="30H73N" id="I54NGzty4g" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="I54NGztyvi" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tp2q:hrElVp8" resolve="key" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="I54NGztBRZ" role="sgxqj">
+            <node concept="1eOMI4" id="I54NGztBS0" role="2Oq$k0">
+              <node concept="10QFUN" id="I54NGztBS1" role="1eOMHV">
+                <node concept="10Nm6u" id="I54NGztBS2" role="10QFUP" />
+                <node concept="3uibUv" id="I54NGztBS3" role="10QFUM">
+                  <ref role="3uigEE" to="urs3:5Ffu4tBU$6H" resolve="IMapSequence" />
+                </node>
+              </node>
+              <node concept="1sPUBX" id="I54NGztBS4" role="lGtFl">
+                <ref role="v9R2y" to="tp2r:hwGFo3P" resolve="switch_sequence_operation_toSequence" />
+                <node concept="3NFfHV" id="I54NGztBS5" role="1sPUBK">
+                  <node concept="3clFbS" id="I54NGztBS6" role="2VODD2">
+                    <node concept="3clFbF" id="I54NGztBS7" role="3cqZAp">
+                      <node concept="2OqwBi" id="I54NGztBS8" role="3clFbG">
+                        <node concept="30H73N" id="I54NGztBS9" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="I54NGztBSa" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="I54NGztBSb" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Map.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="10Nm6u" id="I54NGztBSc" role="37wK5m">
+                <node concept="29HgVG" id="I54NGztBSd" role="lGtFl">
+                  <node concept="3NFfHV" id="I54NGztBSe" role="3NFExx">
+                    <node concept="3clFbS" id="I54NGztBSf" role="2VODD2">
+                      <node concept="3clFbF" id="I54NGztBSg" role="3cqZAp">
+                        <node concept="2OqwBi" id="I54NGztBSh" role="3clFbG">
+                          <node concept="30H73N" id="I54NGztBSi" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="I54NGztBSj" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tp2q:hrElVp8" resolve="key" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OlCPf" id="I54NGztGqq" role="37wK5m" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4OYzberlhCN" role="2OlCPR">
+            <node concept="2OqwBi" id="I54NGzt$rS" role="2Oq$k0">
+              <node concept="1eOMI4" id="I54NGzt$rT" role="2Oq$k0">
+                <node concept="10QFUN" id="I54NGzt$rU" role="1eOMHV">
+                  <node concept="10Nm6u" id="I54NGzt$rV" role="10QFUP" />
+                  <node concept="3uibUv" id="I54NGzt$rW" role="10QFUM">
+                    <ref role="3uigEE" to="urs3:5Ffu4tBU$6H" resolve="IMapSequence" />
+                  </node>
+                </node>
+                <node concept="1sPUBX" id="I54NGzt$rX" role="lGtFl">
+                  <ref role="v9R2y" to="tp2r:hwGFo3P" resolve="switch_sequence_operation_toSequence" />
+                  <node concept="3NFfHV" id="I54NGzt$rY" role="1sPUBK">
+                    <node concept="3clFbS" id="I54NGzt$rZ" role="2VODD2">
+                      <node concept="3clFbF" id="I54NGzt$s0" role="3cqZAp">
+                        <node concept="2OqwBi" id="I54NGzt$s1" role="3clFbG">
+                          <node concept="30H73N" id="I54NGzt$s2" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="I54NGzt$s3" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="4OYzberlgsu" role="2OqNvi">
+                <ref role="37wK5l" to="urs3:5Ffu4tBU$7h" resolve="toMap" />
+              </node>
+            </node>
+            <node concept="liA8E" id="4OYzberll27" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Map.computeIfAbsent(java.lang.Object,java.util.function.Function)" resolve="computeIfAbsent" />
+              <node concept="10Nm6u" id="I54NGzt$s5" role="37wK5m">
+                <node concept="29HgVG" id="I54NGzt$s6" role="lGtFl">
+                  <node concept="3NFfHV" id="I54NGzt$s7" role="3NFExx">
+                    <node concept="3clFbS" id="I54NGzt$s8" role="2VODD2">
+                      <node concept="3clFbF" id="I54NGzt$s9" role="3cqZAp">
+                        <node concept="2OqwBi" id="I54NGzt$sa" role="3clFbG">
+                          <node concept="30H73N" id="I54NGzt$sb" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="I54NGzt$sc" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tp2q:hrElVp8" resolve="key" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="10Nm6u" id="4OYzberqpPn" role="37wK5m">
+                <node concept="1sPUBX" id="4OYzberqqML" role="lGtFl">
+                  <ref role="v9R2y" node="54jQkZ9fKWX" resolve="switchClosureLiteral" />
+                  <node concept="3NFfHV" id="4OYzberqr$f" role="1sPUBK">
+                    <node concept="3clFbS" id="4OYzberqr$g" role="2VODD2">
+                      <node concept="3clFbF" id="4OYzberqsmX" role="3cqZAp">
+                        <node concept="2OqwBi" id="4OYzberqs_y" role="3clFbG">
+                          <node concept="30H73N" id="4OYzberqsmW" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="4OYzberqt67" role="2OqNvi">
+                            <ref role="3Tt5mk" to="pkab:4OYzberaMVq" resolve="closure" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
@@ -1034,6 +1034,116 @@
         </node>
       </node>
     </node>
+    <node concept="3aamgX" id="7kYXsDneRDJ" role="3acgRq">
+      <ref role="30HIoZ" to="tpee:hqOqwz4" resolve="DotExpression" />
+      <node concept="30G5F_" id="7kYXsDneUWt" role="30HLyM">
+        <node concept="3clFbS" id="7kYXsDneUWu" role="2VODD2">
+          <node concept="3clFbF" id="7kYXsDneUXC" role="3cqZAp">
+            <node concept="2OqwBi" id="7kYXsDneW2V" role="3clFbG">
+              <node concept="2OqwBi" id="7kYXsDneVhf" role="2Oq$k0">
+                <node concept="30H73N" id="7kYXsDneUXB" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7kYXsDneVQh" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="7kYXsDneWsb" role="2OqNvi">
+                <node concept="chp4Y" id="7kYXsDneWt8" role="cj9EA">
+                  <ref role="cht4Q" to="pkab:3bMhTtR51d8" resolve="GetOrComputeOperation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="gft3U" id="7kYXsDneWDn" role="1lVwrX">
+        <node concept="2OqwBi" id="7kYXsDnf2YG" role="gfFT$">
+          <node concept="2OqwBi" id="7kYXsDneWEp" role="2Oq$k0">
+            <node concept="1eOMI4" id="7kYXsDneWEA" role="2Oq$k0">
+              <node concept="10QFUN" id="7kYXsDneWEz" role="1eOMHV">
+                <node concept="3uibUv" id="7kYXsDneWFC" role="10QFUM">
+                  <ref role="3uigEE" to="urs3:5Ffu4tBU$6H" resolve="IMapSequence" />
+                </node>
+                <node concept="10Nm6u" id="7kYXsDneX2N" role="10QFUP" />
+              </node>
+              <node concept="1sPUBX" id="7kYXsDneX36" role="lGtFl">
+                <ref role="v9R2y" to="tp2r:hwGFo3P" resolve="switch_sequence_operation_toSequence" />
+                <node concept="3NFfHV" id="7kYXsDnf7EO" role="1sPUBK">
+                  <node concept="3clFbS" id="7kYXsDnf7EP" role="2VODD2">
+                    <node concept="3clFbF" id="7kYXsDnf7UM" role="3cqZAp">
+                      <node concept="2OqwBi" id="7kYXsDnf8aM" role="3clFbG">
+                        <node concept="30H73N" id="7kYXsDnf7UL" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="7kYXsDnf8M6" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="7kYXsDnf0$4" role="2OqNvi">
+              <ref role="37wK5l" to="urs3:5Ffu4tBU$7h" resolve="toMap" />
+            </node>
+          </node>
+          <node concept="liA8E" id="7kYXsDnf6cB" role="2OqNvi">
+            <ref role="37wK5l" to="33ny:~Map.computeIfAbsent(java.lang.Object,java.util.function.Function)" resolve="computeIfAbsent" />
+            <node concept="10Nm6u" id="7kYXsDnf6Zu" role="37wK5m">
+              <node concept="29HgVG" id="7kYXsDnf8QF" role="lGtFl">
+                <node concept="3NFfHV" id="7kYXsDnf8QG" role="3NFExx">
+                  <node concept="3clFbS" id="7kYXsDnf8QH" role="2VODD2">
+                    <node concept="3clFbF" id="7kYXsDnf8QN" role="3cqZAp">
+                      <node concept="2OqwBi" id="7kYXsDnf9Wu" role="3clFbG">
+                        <node concept="1PxgMI" id="7kYXsDnf9GK" role="2Oq$k0">
+                          <node concept="chp4Y" id="7kYXsDnf9HZ" role="3oSUPX">
+                            <ref role="cht4Q" to="pkab:3bMhTtR51d8" resolve="GetOrComputeOperation" />
+                          </node>
+                          <node concept="2OqwBi" id="7kYXsDnf8QI" role="1m5AlR">
+                            <node concept="3TrEf2" id="7kYXsDnf8QL" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                            </node>
+                            <node concept="30H73N" id="7kYXsDnf8QM" role="2Oq$k0" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="7kYXsDnfagC" role="2OqNvi">
+                          <ref role="3Tt5mk" to="pkab:3bMhTtR51da" resolve="key" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="10Nm6u" id="7kYXsDnfbVA" role="37wK5m">
+              <node concept="1sPUBX" id="7kYXsDnfcgc" role="lGtFl">
+                <ref role="v9R2y" node="54jQkZ9fKWX" resolve="switchClosureLiteral" />
+                <node concept="3NFfHV" id="7kYXsDnfcuW" role="1sPUBK">
+                  <node concept="3clFbS" id="7kYXsDnfcuX" role="2VODD2">
+                    <node concept="3clFbF" id="7kYXsDnfcIW" role="3cqZAp">
+                      <node concept="2OqwBi" id="7kYXsDnfdWz" role="3clFbG">
+                        <node concept="1PxgMI" id="7kYXsDnfdIO" role="2Oq$k0">
+                          <node concept="chp4Y" id="7kYXsDnfdJM" role="3oSUPX">
+                            <ref role="cht4Q" to="pkab:3bMhTtR51d8" resolve="GetOrComputeOperation" />
+                          </node>
+                          <node concept="2OqwBi" id="7kYXsDnfcXI" role="1m5AlR">
+                            <node concept="30H73N" id="7kYXsDnfcIV" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="7kYXsDnfdyQ" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="7kYXsDnfeAC" role="2OqNvi">
+                          <ref role="3Tt5mk" to="pkab:3bMhTtR51d9" resolve="closure" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="3aamgX" id="4OYzberkEy$" role="3acgRq">
       <ref role="30HIoZ" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
       <node concept="gft3U" id="4OYzberkG_c" role="1lVwrX">

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.behavior.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.behavior.mps
@@ -4,9 +4,247 @@
   <languages>
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
+    <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tp2c" ref="r:00000000-0000-4000-0000-011c89590338(jetbrains.mps.baseLanguage.closures.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
+        <reference id="1225194240799" name="concept" index="13h7C2" />
+        <child id="1225194240801" name="constructor" index="13h7CW" />
+      </concept>
+      <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
+      <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
+      <concept id="1178870617262" name="jetbrains.mps.lang.typesystem.structure.CoerceExpression" flags="nn" index="1UaxmW">
+        <child id="1178870894644" name="pattern" index="1Ub_4A" />
+        <child id="1178870894645" name="nodeToCoerce" index="1Ub_4B" />
+      </concept>
+      <concept id="1178871491133" name="jetbrains.mps.lang.typesystem.structure.CoerceStrongExpression" flags="nn" index="1UdQGJ" />
+      <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
+        <reference id="1174642800329" name="concept" index="1YaFvo" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
+        <child id="1140725362529" name="linkTarget" index="2oxUTC" />
+      </concept>
+      <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC">
+        <reference id="1139880128956" name="concept" index="1A9B2P" />
+      </concept>
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
+        <reference id="1139877738879" name="concept" index="1A0vxQ" />
+      </concept>
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="13h7C7" id="3bMhTtR6TXv">
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <ref role="13h7C2" to="pkab:3bMhTtR51d8" resolve="GetOrComputeOperation" />
+    <node concept="13hLZK" id="3bMhTtR6TXw" role="13h7CW">
+      <node concept="3clFbS" id="3bMhTtR6TXx" role="2VODD2">
+        <node concept="3cpWs8" id="7kYXsDnkXjF" role="3cqZAp">
+          <node concept="3cpWsn" id="7kYXsDnkXjI" role="3cpWs9">
+            <property role="TrG5h" value="mapType" />
+            <node concept="3Tqbb2" id="7kYXsDnkXjD" role="1tU5fm">
+              <ref role="ehGHo" to="tp2q:hrrvAJb" resolve="MapType" />
+            </node>
+            <node concept="1UdQGJ" id="7kYXsDnkZCL" role="33vP2m">
+              <node concept="2OqwBi" id="7kYXsDnmwH9" role="1Ub_4B">
+                <node concept="2OqwBi" id="7kYXsDnl0NN" role="2Oq$k0">
+                  <node concept="1PxgMI" id="7kYXsDnl0BW" role="2Oq$k0">
+                    <node concept="chp4Y" id="7kYXsDnl0CN" role="3oSUPX">
+                      <ref role="cht4Q" to="tpee:hqOqwz4" resolve="DotExpression" />
+                    </node>
+                    <node concept="2OqwBi" id="7kYXsDnkZXY" role="1m5AlR">
+                      <node concept="13iPFW" id="7kYXsDnkZCP" role="2Oq$k0" />
+                      <node concept="1mfA1w" id="7kYXsDnl0wv" role="2OqNvi" />
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="7kYXsDnl1wi" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+                  </node>
+                </node>
+                <node concept="3JvlWi" id="7kYXsDnmx6P" role="2OqNvi" />
+              </node>
+              <node concept="1YaCAy" id="7kYXsDnkZCN" role="1Ub_4A">
+                <property role="TrG5h" value="mapType" />
+                <ref role="1YaFvo" to="tp2q:hrrvAJb" resolve="MapType" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7kYXsDndOUJ" role="3cqZAp">
+          <node concept="3cpWsn" id="7kYXsDndOUK" role="3cpWs9">
+            <property role="TrG5h" value="closure" />
+            <node concept="3Tqbb2" id="7kYXsDndODN" role="1tU5fm">
+              <ref role="ehGHo" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+            </node>
+            <node concept="2OqwBi" id="7kYXsDndOUL" role="33vP2m">
+              <node concept="2OqwBi" id="7kYXsDndOUM" role="2Oq$k0">
+                <node concept="13iPFW" id="7kYXsDndOUN" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7kYXsDndOUO" role="2OqNvi">
+                  <ref role="3Tt5mk" to="pkab:3bMhTtR51d9" resolve="closure" />
+                </node>
+              </node>
+              <node concept="zfrQC" id="7kYXsDndOUP" role="2OqNvi">
+                <ref role="1A9B2P" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7kYXsDnkS40" role="3cqZAp">
+          <node concept="3cpWsn" id="7kYXsDnkS41" role="3cpWs9">
+            <property role="TrG5h" value="param" />
+            <node concept="3Tqbb2" id="7kYXsDnkRS$" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="7kYXsDnkS42" role="33vP2m">
+              <node concept="2OqwBi" id="7kYXsDnkS43" role="2Oq$k0">
+                <node concept="37vLTw" id="7kYXsDnkS44" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7kYXsDndOUK" resolve="closure" />
+                </node>
+                <node concept="3Tsc0h" id="7kYXsDnkS45" role="2OqNvi">
+                  <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                </node>
+              </node>
+              <node concept="WFELt" id="7kYXsDnkS46" role="2OqNvi">
+                <ref role="1A0vxQ" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3bMhTtR6X9$" role="3cqZAp">
+          <node concept="37vLTI" id="3bMhTtR7gr2" role="3clFbG">
+            <node concept="Xl_RD" id="3bMhTtR7gsp" role="37vLTx">
+              <property role="Xl_RC" value="key" />
+            </node>
+            <node concept="2OqwBi" id="3bMhTtR7ewQ" role="37vLTJ">
+              <node concept="37vLTw" id="7kYXsDnkS47" role="2Oq$k0">
+                <ref role="3cqZAo" node="7kYXsDnkS41" resolve="addNew" />
+              </node>
+              <node concept="3TrcHB" id="3bMhTtR7fQn" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7kYXsDnkTh1" role="3cqZAp">
+          <node concept="2OqwBi" id="7kYXsDnkVyg" role="3clFbG">
+            <node concept="2OqwBi" id="7kYXsDnkUCq" role="2Oq$k0">
+              <node concept="37vLTw" id="7kYXsDnkTgZ" role="2Oq$k0">
+                <ref role="3cqZAo" node="7kYXsDnkS41" resolve="param" />
+              </node>
+              <node concept="3TrEf2" id="7kYXsDnkVd9" role="2OqNvi">
+                <ref role="3Tt5mk" to="tpee:4VkOLwjf83e" resolve="type" />
+              </node>
+            </node>
+            <node concept="2oxUTD" id="7kYXsDnkW1E" role="2OqNvi">
+              <node concept="2OqwBi" id="7kYXsDnl33E" role="2oxUTC">
+                <node concept="2OqwBi" id="7kYXsDnl27F" role="2Oq$k0">
+                  <node concept="37vLTw" id="7kYXsDnl1Q1" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7kYXsDnkXjI" resolve="mapType" />
+                  </node>
+                  <node concept="3TrEf2" id="7kYXsDnl2NG" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tp2q:hrrvQaC" resolve="keyType" />
+                  </node>
+                </node>
+                <node concept="1$rogu" id="7kYXsDnl3BH" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7kYXsDndP21" role="3cqZAp">
+          <node concept="2OqwBi" id="7kYXsDndQ4x" role="3clFbG">
+            <node concept="2OqwBi" id="7kYXsDndPlx" role="2Oq$k0">
+              <node concept="37vLTw" id="7kYXsDndP1Z" role="2Oq$k0">
+                <ref role="3cqZAo" node="7kYXsDndOUK" resolve="closure" />
+              </node>
+              <node concept="3TrEf2" id="7kYXsDndPJP" role="2OqNvi">
+                <ref role="3Tt5mk" to="tp2c:htbW58J" resolve="body" />
+              </node>
+            </node>
+            <node concept="zfrQC" id="7kYXsDndR_i" role="2OqNvi">
+              <ref role="1A9B2P" to="tpee:fzclF80" resolve="StatementList" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.dataFlow.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.dataFlow.mps
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:cacb8854-d795-42b3-9995-ed5a346fcbc5(de.itemis.mps.baseLanguageExtensions.dataFlow)">
+  <persistence version="9" />
+  <languages>
+    <use id="7fa12e9c-b949-4976-b4fa-19accbc320b4" name="jetbrains.mps.lang.dataFlow" version="1" />
+    <devkit ref="00000000-0000-4000-0000-443879f56b80(jetbrains.mps.devkit.aspect.dataflow)" />
+  </languages>
+  <imports>
+    <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
+    <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="7fa12e9c-b949-4976-b4fa-19accbc320b4" name="jetbrains.mps.lang.dataFlow">
+      <concept id="1206442055221" name="jetbrains.mps.lang.dataFlow.structure.DataFlowBuilderDeclaration" flags="ig" index="3_zdsH">
+        <reference id="1206442096288" name="conceptDeclaration" index="3_znuS" />
+        <child id="1206442812839" name="builderBlock" index="3_A6iZ" />
+      </concept>
+      <concept id="1206442659665" name="jetbrains.mps.lang.dataFlow.structure.BuilderBlock" flags="in" index="3__wT9" />
+      <concept id="1206442747519" name="jetbrains.mps.lang.dataFlow.structure.NodeParameter" flags="nn" index="3__QtB" />
+      <concept id="1206454052847" name="jetbrains.mps.lang.dataFlow.structure.EmitCodeForStatement" flags="nn" index="3AgYrR">
+        <child id="1206454079161" name="codeFor" index="3Ah4Yx" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="3_zdsH" id="4OYzbercche">
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <ref role="3_znuS" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
+    <node concept="3__wT9" id="4OYzbercchf" role="3_A6iZ">
+      <node concept="3clFbS" id="4OYzbercchg" role="2VODD2">
+        <node concept="3AgYrR" id="4OYzberccj$" role="3cqZAp">
+          <node concept="2OqwBi" id="4OYzbercctP" role="3Ah4Yx">
+            <node concept="3__QtB" id="4OYzbercck1" role="2Oq$k0" />
+            <node concept="3TrEf2" id="4OYzbercd1m" role="2OqNvi">
+              <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
+            </node>
+          </node>
+        </node>
+        <node concept="3AgYrR" id="4OYzbercd4T" role="3cqZAp">
+          <node concept="2OqwBi" id="4OYzbercd5N" role="3Ah4Yx">
+            <node concept="3__QtB" id="4OYzbercd5z" role="2Oq$k0" />
+            <node concept="3TrEf2" id="4OYzbercd84" role="2OqNvi">
+              <ref role="3Tt5mk" to="tp2q:hrElVp8" resolve="key" />
+            </node>
+          </node>
+        </node>
+        <node concept="3AgYrR" id="4OYzbercdhy" role="3cqZAp">
+          <node concept="2OqwBi" id="4OYzbercdsb" role="3Ah4Yx">
+            <node concept="3__QtB" id="4OYzbercdin" role="2Oq$k0" />
+            <node concept="3TrEf2" id="4OYzberce0M" role="2OqNvi">
+              <ref role="3Tt5mk" to="pkab:4OYzberaMVq" resolve="closure" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.dataFlow.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.dataFlow.mps
@@ -18,6 +18,10 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
@@ -29,11 +33,20 @@
       </concept>
       <concept id="1206442659665" name="jetbrains.mps.lang.dataFlow.structure.BuilderBlock" flags="in" index="3__wT9" />
       <concept id="1206442747519" name="jetbrains.mps.lang.dataFlow.structure.NodeParameter" flags="nn" index="3__QtB" />
+      <concept id="1206444910183" name="jetbrains.mps.lang.dataFlow.structure.RelativePosition" flags="ng" index="3_I6tZ">
+        <child id="1206444923842" name="relativeTo" index="3_I9Fq" />
+      </concept>
+      <concept id="1206445082906" name="jetbrains.mps.lang.dataFlow.structure.AfterPosition" flags="ng" index="3_IKw2" />
+      <concept id="1206445181593" name="jetbrains.mps.lang.dataFlow.structure.BaseEmitJumpStatement" flags="nn" index="3_J8I1">
+        <child id="1206445193860" name="jumpTo" index="3_JbIs" />
+      </concept>
+      <concept id="1206445295557" name="jetbrains.mps.lang.dataFlow.structure.EmitIfJumpStatement" flags="nn" index="3_J$rt" />
       <concept id="1206454052847" name="jetbrains.mps.lang.dataFlow.structure.EmitCodeForStatement" flags="nn" index="3AgYrR">
         <child id="1206454079161" name="codeFor" index="3Ah4Yx" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
@@ -65,11 +78,58 @@
             </node>
           </node>
         </node>
+        <node concept="3_J$rt" id="3bMhTtR5Ghz" role="3cqZAp">
+          <node concept="3_IKw2" id="3bMhTtR5Git" role="3_JbIs">
+            <node concept="3__QtB" id="3bMhTtR5GiW" role="3_I9Fq" />
+          </node>
+        </node>
         <node concept="3AgYrR" id="4OYzbercdhy" role="3cqZAp">
           <node concept="2OqwBi" id="4OYzbercdsb" role="3Ah4Yx">
             <node concept="3__QtB" id="4OYzbercdin" role="2Oq$k0" />
             <node concept="3TrEf2" id="4OYzberce0M" role="2OqNvi">
               <ref role="3Tt5mk" to="pkab:4OYzberaMVq" resolve="closure" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3_zdsH" id="3bMhTtR5Gkv">
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <ref role="3_znuS" to="pkab:3bMhTtR51d8" resolve="GetOrComputeOperation" />
+    <node concept="3__wT9" id="3bMhTtR5Gkw" role="3_A6iZ">
+      <node concept="3clFbS" id="3bMhTtR5Gkx" role="2VODD2">
+        <node concept="3clFbJ" id="7kYXsDn9VtX" role="3cqZAp">
+          <node concept="3clFbS" id="7kYXsDn9VtZ" role="3clFbx">
+            <node concept="3AgYrR" id="3bMhTtR5GkU" role="3cqZAp">
+              <node concept="2OqwBi" id="3bMhTtR5Gv_" role="3Ah4Yx">
+                <node concept="3__QtB" id="3bMhTtR5Gln" role="2Oq$k0" />
+                <node concept="3TrEf2" id="3bMhTtR5GKC" role="2OqNvi">
+                  <ref role="3Tt5mk" to="pkab:3bMhTtR51da" resolve="key" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7kYXsDn9WaP" role="3clFbw">
+            <node concept="2OqwBi" id="7kYXsDn9VIk" role="2Oq$k0">
+              <node concept="3__QtB" id="7kYXsDn9VyA" role="2Oq$k0" />
+              <node concept="3TrEf2" id="7kYXsDn9W0t" role="2OqNvi">
+                <ref role="3Tt5mk" to="pkab:3bMhTtR51da" resolve="key" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="7kYXsDn9X03" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3_J$rt" id="3bMhTtR5GOh" role="3cqZAp">
+          <node concept="3_IKw2" id="3bMhTtR5GOP" role="3_JbIs">
+            <node concept="3__QtB" id="3bMhTtR5GPk" role="3_I9Fq" />
+          </node>
+        </node>
+        <node concept="3AgYrR" id="3bMhTtR5GQn" role="3cqZAp">
+          <node concept="2OqwBi" id="3bMhTtR5GRF" role="3Ah4Yx">
+            <node concept="3__QtB" id="3bMhTtR5GR7" role="2Oq$k0" />
+            <node concept="3TrEf2" id="3bMhTtR5GSQ" role="2OqNvi">
+              <ref role="3Tt5mk" to="pkab:3bMhTtR51d9" resolve="closure" />
             </node>
           </node>
         </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.editor.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.editor.mps
@@ -839,5 +839,42 @@
       </node>
     </node>
   </node>
+  <node concept="24kQdi" id="3bMhTtR5JMX">
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <ref role="1XX52x" to="pkab:3bMhTtR51d8" resolve="GetOrComputeOperation" />
+    <node concept="3EZMnI" id="3bMhTtR5JMZ" role="2wV5jI">
+      <node concept="PMmxH" id="3bMhTtR5JN3" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      </node>
+      <node concept="3F0ifn" id="3bMhTtR5JN5" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <node concept="11L4FC" id="3bMhTtR5JNk" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="3bMhTtR5JNm" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="3bMhTtR5JNb" role="3EZMnx">
+        <ref role="1NtTu8" to="pkab:3bMhTtR51da" resolve="key" />
+      </node>
+      <node concept="3F0ifn" id="3bMhTtR5JNe" role="3EZMnx">
+        <property role="3F0ifm" value="," />
+        <node concept="11L4FC" id="3bMhTtR5JNj" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="3bMhTtR5JNh" role="3EZMnx">
+        <ref role="1NtTu8" to="pkab:3bMhTtR51d9" resolve="closure" />
+      </node>
+      <node concept="3F0ifn" id="3bMhTtR5JN8" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <node concept="11LMrY" id="3bMhTtR5JNo" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="3bMhTtR8zqz" role="2iSdaV" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.editor.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.editor.mps
@@ -4,13 +4,20 @@
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
+    <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" />
+    <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" />
+    <import index="tp2u" ref="r:00000000-0000-4000-0000-011c8959032a(jetbrains.mps.baseLanguage.collections.editor)" />
     <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
-    <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tp2c" ref="r:00000000-0000-4000-0000-011c89590338(jetbrains.mps.baseLanguage.closures.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -20,8 +27,17 @@
         <child id="414384289274416996" name="parts" index="3ft7WO" />
       </concept>
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
+      <concept id="540685334799965957" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenuVariable_Initializer" flags="ig" index="23wN_R" />
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1597643335227097138" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_TransformationMenu_node" flags="ng" index="7Obwk" />
+      <concept id="6516520003787916624" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Condition" flags="ig" index="27VH4U" />
+      <concept id="7429591467341004871" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_Group" flags="ng" index="aenpk">
+        <child id="7429591467341004872" name="parts" index="aenpr" />
+        <child id="7429591467341004877" name="condition" index="aenpu" />
+        <child id="7655327340756279373" name="variables" index="1b80Z_" />
+      </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="8954657570916342474" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Node" flags="ig" index="2jZ$Xn" />
       <concept id="6089045305654894367" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Named" flags="ng" index="2kknPI">
         <reference id="6089045305654944382" name="menu" index="2kkw0f" />
       </concept>
@@ -35,9 +51,24 @@
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
+      <concept id="6718020819487620873" name="jetbrains.mps.lang.editor.structure.TransformationMenuReference_Named" flags="ng" index="A1WHu">
+        <reference id="6718020819487620874" name="menu" index="A1WHt" />
+      </concept>
+      <concept id="3547227755871693971" name="jetbrains.mps.lang.editor.structure.PredefinedSelector" flags="ng" index="2B6iha">
+        <property id="2162403111523065396" name="cellId" index="1lyBwo" />
+      </concept>
+      <concept id="3473224453637651916" name="jetbrains.mps.lang.editor.structure.TransformationLocation_SideTransform_PlaceInCellHolder" flags="ng" index="CtIbL">
+        <property id="3473224453637651917" name="placeInCell" index="CtIbK" />
+      </concept>
+      <concept id="1638911550608610798" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Execute" flags="ig" index="IWg2L" />
+      <concept id="1638911550608610278" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_Action" flags="ng" index="IWgqT">
+        <child id="1638911550608610281" name="executeFunction" index="IWgqQ" />
+        <child id="5692353713941573325" name="textFunction" index="1hCUd6" />
+      </concept>
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
+      <concept id="4323500428121233431" name="jetbrains.mps.lang.editor.structure.EditorCellId" flags="ng" index="2SqB2G" />
       <concept id="615427434521884870" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Subconcepts" flags="ng" index="2VfDsV" />
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
@@ -47,6 +78,8 @@
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
         <child id="5991739802479788259" name="type" index="22hAXT" />
       </concept>
+      <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
+      <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
       <concept id="8998492695583109601" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_CanSubstitute" flags="ig" index="16Na2f" />
       <concept id="8998492695583125082" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_MatchingText" flags="ng" index="16NfWO">
         <child id="8998492695583129244" name="query" index="16NeZM" />
@@ -54,8 +87,22 @@
       <concept id="8998492695583129991" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_CanSubstitute" flags="ng" index="16NL3D">
         <child id="8998492695583129992" name="query" index="16NL3A" />
       </concept>
+      <concept id="1838685759388685703" name="jetbrains.mps.lang.editor.structure.TransformationFeature_DescriptionText" flags="ng" index="3cqGtN">
+        <child id="1838685759388685704" name="query" index="3cqGtW" />
+      </concept>
+      <concept id="1838685759388690418" name="jetbrains.mps.lang.editor.structure.TransformationFeature_ActionType" flags="ng" index="3cqJk6">
+        <child id="1838685759388690419" name="query" index="3cqJk7" />
+      </concept>
+      <concept id="1838685759388690401" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_DescriptionText" flags="ig" index="3cqJkl" />
+      <concept id="2896773699153795590" name="jetbrains.mps.lang.editor.structure.TransformationLocation_SideTransform" flags="ng" index="3cWJ9i">
+        <child id="3473224453637651919" name="placeInCell" index="CtIbM" />
+      </concept>
       <concept id="7342352913006985483" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Action" flags="ng" index="3eGOop">
         <child id="8612453216082699922" name="substituteHandler" index="3aKz83" />
+      </concept>
+      <concept id="5692353713941573329" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_ActionLabelText" flags="ig" index="1hCUdq" />
+      <concept id="7291101478617127464" name="jetbrains.mps.lang.editor.structure.IExtensibleTransformationMenuPart" flags="ng" index="1joUw2">
+        <child id="8954657570916349207" name="features" index="2jZA2a" />
       </concept>
       <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
@@ -64,13 +111,21 @@
       <concept id="730181322658904464" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_IncludeMenu" flags="ng" index="1s_PAr">
         <child id="730181322658904467" name="menuReference" index="1s_PAo" />
       </concept>
+      <concept id="2314756748950088783" name="jetbrains.mps.lang.editor.structure.TransformationMenuVariableReference" flags="ng" index="3yx0qK" />
       <concept id="5425882385312046132" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_CurrentTargetNode" flags="nn" index="1yR$tW" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <property id="1139852716018" name="noTargetText" index="1$x2rV" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
+      <concept id="1178539929008" name="jetbrains.mps.lang.editor.structure.TransformationMenuVariableDeclaration" flags="ig" index="1At2My">
+        <child id="540685334799973431" name="initializerBlock" index="23wLD5" />
+      </concept>
       <concept id="7991336459489871999" name="jetbrains.mps.lang.editor.structure.IOutputConceptSubstituteMenuPart" flags="ng" index="3EoQpk">
         <reference id="7991336459489872009" name="outputConcept" index="3EoQqy" />
+      </concept>
+      <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
+        <reference id="1139959269582" name="actionMap" index="1ERwB7" />
+        <child id="4323500428121274054" name="id" index="2SqHTX" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
@@ -86,6 +141,28 @@
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY">
         <property id="16410578721444372" name="customizeEmptyCell" index="2ru_X1" />
         <child id="16410578721629643" name="emptyCellModel" index="2ruayu" />
+      </concept>
+      <concept id="843003353410421268" name="jetbrains.mps.lang.editor.structure.IOutputConceptTransformationMenuPart" flags="ng" index="1FNN41">
+        <child id="843003353410424960" name="outputConceptReference" index="1FNMel" />
+      </concept>
+      <concept id="843003353410421233" name="jetbrains.mps.lang.editor.structure.OptionalConceptReference" flags="ng" index="1FNNb$">
+        <reference id="843003353410421234" name="concept" index="1FNNbB" />
+      </concept>
+      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
+        <child id="1638911550608572412" name="sections" index="IW6Ez" />
+      </concept>
+      <concept id="5624877018228264944" name="jetbrains.mps.lang.editor.structure.TransformationMenuContribution" flags="ng" index="3INDKC">
+        <child id="6718020819489956031" name="menuReference" index="AmTjC" />
+      </concept>
+      <concept id="3647146066980922272" name="jetbrains.mps.lang.editor.structure.SelectInEditorOperation" flags="nn" index="1OKiuA">
+        <child id="1948540814633499358" name="editorContext" index="lBI5i" />
+        <child id="1948540814635895774" name="cellSelector" index="lGT1i" />
+        <child id="3604384757217586546" name="selectionStart" index="3dN3m$" />
+      </concept>
+      <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
+      <concept id="7980428675268276156" name="jetbrains.mps.lang.editor.structure.TransformationMenuSection" flags="ng" index="1Qtc8_">
+        <child id="7980428675268276157" name="locations" index="1Qtc8$" />
+        <child id="7980428675268276159" name="parts" index="1Qtc8A" />
       </concept>
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
@@ -105,6 +182,9 @@
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
@@ -160,24 +240,61 @@
         <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
     </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
+      <concept id="1178870617262" name="jetbrains.mps.lang.typesystem.structure.CoerceExpression" flags="nn" index="1UaxmW">
+        <child id="1178870894644" name="pattern" index="1Ub_4A" />
+        <child id="1178870894645" name="nodeToCoerce" index="1Ub_4B" />
+      </concept>
+      <concept id="1178871491133" name="jetbrains.mps.lang.typesystem.structure.CoerceStrongExpression" flags="nn" index="1UdQGJ" />
+      <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
+        <reference id="1174642800329" name="concept" index="1YaFvo" />
+      </concept>
+    </language>
     <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="767145758118872833" name="jetbrains.mps.lang.actions.structure.NF_LinkList_AddNewChildOperation" flags="nn" index="2DeJg1" />
+      <concept id="767145758118872828" name="jetbrains.mps.lang.actions.structure.NF_Node_ReplaceWithNewOperation" flags="nn" index="2DeJnW" />
+      <concept id="767145758118872830" name="jetbrains.mps.lang.actions.structure.NF_Link_SetNewChildOperation" flags="nn" index="2DeJnY" />
       <concept id="5480835971642155304" name="jetbrains.mps.lang.actions.structure.NF_Model_CreateNewNodeOperation" flags="nn" index="15TzpJ" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
+        <child id="1140725362529" name="linkTarget" index="2oxUTC" />
+      </concept>
+      <concept id="1138661924179" name="jetbrains.mps.lang.smodel.structure.Property_SetOperation" flags="nn" index="tyxLq">
+        <child id="1138662048170" name="value" index="tz02z" />
+      </concept>
+      <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC">
+        <reference id="1139880128956" name="concept" index="1A9B2P" />
+      </concept>
       <concept id="1143235216708" name="jetbrains.mps.lang.smodel.structure.Model_CreateNewNodeOperation" flags="nn" index="I8ghe">
         <reference id="1143235391024" name="concept" index="I8UWU" />
       </concept>
+      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
+        <reference id="1139877738879" name="concept" index="1A0vxQ" />
+      </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1139867745658" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithNewOperation" flags="nn" index="1_qnLN">
+        <reference id="1139867957129" name="concept" index="1_rbq0" />
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -436,6 +553,290 @@
         <ref role="1k5W1q" to="tpen:hFCSUmN" resolve="RightParen" />
       </node>
       <node concept="2iRfu4" id="2oJmO5M1wK5" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="4OYzberaNGS">
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <ref role="1XX52x" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
+    <node concept="3EZMnI" id="hrEmePk" role="2wV5jI">
+      <node concept="3F1sOY" id="hrEmfD6" role="3EZMnx">
+        <ref role="1NtTu8" to="tp2q:hrElQF7" resolve="map" />
+      </node>
+      <node concept="3EZMnI" id="4B_rn7pJMaZ" role="3EZMnx">
+        <node concept="l2Vlx" id="4B_rn7pJMb0" role="2iSdaV" />
+        <node concept="3F0ifn" id="hrEmgfH" role="3EZMnx">
+          <property role="3F0ifm" value="[" />
+          <ref role="1k5W1q" to="tpen:hF$iDz7" resolve="Bracket" />
+          <ref role="1ERwB7" to="tp2u:7YLJXJK6FoA" resolve="MapElement_DELETE" />
+          <node concept="11L4FC" id="hY3GY9I" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="11LMrY" id="hYakOBA" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F1sOY" id="hrEmh6r" role="3EZMnx">
+          <ref role="1NtTu8" to="tp2q:hrElVp8" resolve="key" />
+          <ref role="1ERwB7" to="tp2u:7YLJXJK6FoA" resolve="MapElement_DELETE" />
+        </node>
+        <node concept="3F0ifn" id="4OYzberaNGV" role="3EZMnx">
+          <property role="3F0ifm" value="," />
+          <ref role="1ERwB7" to="tp2u:7YLJXJK6FoA" resolve="MapElement_DELETE" />
+          <node concept="11L4FC" id="4OYzberaNGX" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F1sOY" id="4OYzberaNGZ" role="3EZMnx">
+          <ref role="1NtTu8" to="pkab:4OYzberaMVq" resolve="closure" />
+          <ref role="1ERwB7" to="tp2u:7YLJXJK6FoA" resolve="MapElement_DELETE" />
+        </node>
+        <node concept="3F0ifn" id="hrEmhKW" role="3EZMnx">
+          <property role="3F0ifm" value="]" />
+          <ref role="1k5W1q" to="tpen:hF$iDz7" resolve="Bracket" />
+          <ref role="1ERwB7" to="tp2u:7YLJXJK6FoA" resolve="MapElement_DELETE" />
+          <node concept="11L4FC" id="hYakRj1" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="2SqB2G" id="4B_rn7pJMbs" role="2SqHTX">
+          <property role="TrG5h" value="keyCollection" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="i0MC5Nu" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="22mcaB" id="4OYzberaNL3">
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <ref role="aqKnT" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
+    <node concept="22hDWj" id="4OYzberaNL4" role="22hAXT" />
+  </node>
+  <node concept="3INDKC" id="4OYzbercfto">
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <property role="TrG5h" value="MapGetOrPut" />
+    <node concept="A1WHu" id="4OYzbercftq" role="AmTjC">
+      <ref role="A1WHt" to="tp2u:1wEcoXjJzu$" resolve="BLC_rtansform" />
+    </node>
+    <node concept="1Qtc8_" id="4OYzbercfts" role="IW6Ez">
+      <node concept="3cWJ9i" id="4OYzbercftu" role="1Qtc8$">
+        <node concept="CtIbL" id="4OYzbercftw" role="CtIbM">
+          <property role="CtIbK" value="30NnNOohrQL/RIGHT" />
+        </node>
+      </node>
+      <node concept="aenpk" id="4OYzbercfty" role="1Qtc8A">
+        <node concept="1At2My" id="4OYzbercgmO" role="1b80Z_">
+          <property role="TrG5h" value="mapType" />
+          <node concept="23wN_R" id="4OYzbercgmP" role="23wLD5">
+            <node concept="3clFbS" id="4OYzbercgmQ" role="2VODD2">
+              <node concept="3clFbF" id="1wEcoXjJzuX" role="3cqZAp">
+                <node concept="1UdQGJ" id="1wEcoXjJzuY" role="3clFbG">
+                  <node concept="1YaCAy" id="1wEcoXjJzuZ" role="1Ub_4A">
+                    <property role="TrG5h" value="mapType" />
+                    <ref role="1YaFvo" to="tp2q:hrrvAJb" resolve="MapType" />
+                  </node>
+                  <node concept="2OqwBi" id="1wEcoXjJzv0" role="1Ub_4B">
+                    <node concept="7Obwk" id="1wEcoXjJzv3" role="2Oq$k0" />
+                    <node concept="3JvlWi" id="1wEcoXjJzv2" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3Tqbb2" id="4OYzbercgKR" role="1tU5fm">
+            <ref role="ehGHo" to="tp2q:hrrvAJb" resolve="MapType" />
+          </node>
+        </node>
+        <node concept="27VH4U" id="4OYzbercgTE" role="aenpu">
+          <node concept="3clFbS" id="4OYzbercgTF" role="2VODD2">
+            <node concept="3cpWs8" id="1wEcoXjJzuG" role="3cqZAp">
+              <node concept="3cpWsn" id="1wEcoXjJzuH" role="3cpWs9">
+                <property role="TrG5h" value="type" />
+                <node concept="3Tqbb2" id="1wEcoXjJzuI" role="1tU5fm" />
+                <node concept="2OqwBi" id="1wEcoXjJzuJ" role="33vP2m">
+                  <node concept="7Obwk" id="1wEcoXjJzuS" role="2Oq$k0" />
+                  <node concept="3JvlWi" id="1wEcoXjJzuL" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="1wEcoXjJzuM" role="3cqZAp">
+              <node concept="2OqwBi" id="1wEcoXjJzuN" role="3clFbG">
+                <node concept="1UdQGJ" id="1wEcoXjJzuO" role="2Oq$k0">
+                  <node concept="37vLTw" id="1wEcoXjJzuP" role="1Ub_4B">
+                    <ref role="3cqZAo" node="1wEcoXjJzuH" resolve="type" />
+                  </node>
+                  <node concept="1YaCAy" id="1wEcoXjJzuQ" role="1Ub_4A">
+                    <property role="TrG5h" value="mapType" />
+                    <ref role="1YaFvo" to="tp2q:hrrvAJb" resolve="MapType" />
+                  </node>
+                </node>
+                <node concept="3x8VRR" id="1wEcoXjJzuR" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="IWgqT" id="4OYzbercheN" role="aenpr">
+          <node concept="3cqJk6" id="4OYzberchEO" role="2jZA2a">
+            <node concept="2jZ$Xn" id="4OYzberchEQ" role="3cqJk7">
+              <node concept="3clFbS" id="4OYzberchES" role="2VODD2">
+                <node concept="3clFbF" id="4OYzberci1A" role="3cqZAp">
+                  <node concept="2OqwBi" id="4OYzbercijJ" role="3clFbG">
+                    <node concept="3yx0qK" id="4OYzberci1_" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4OYzbercgmO" resolve="mapType" />
+                    </node>
+                    <node concept="3TrEf2" id="4OYzbercj0D" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tp2q:hrrvSkm" resolve="valueType" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1hCUdq" id="4OYzbercheO" role="1hCUd6">
+            <node concept="3clFbS" id="4OYzbercheP" role="2VODD2">
+              <node concept="3clFbF" id="4OYzberchmi" role="3cqZAp">
+                <node concept="Xl_RD" id="4OYzberchmh" role="3clFbG">
+                  <property role="Xl_RC" value="[ =&gt;" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="IWg2L" id="4OYzbercheQ" role="IWgqQ">
+            <node concept="3clFbS" id="4OYzbercheR" role="2VODD2">
+              <node concept="3cpWs8" id="4OYzbercknw" role="3cqZAp">
+                <node concept="3cpWsn" id="4OYzbercknz" role="3cpWs9">
+                  <property role="TrG5h" value="mapElement" />
+                  <node concept="3Tqbb2" id="4OYzbercknv" role="1tU5fm">
+                    <ref role="ehGHo" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
+                  </node>
+                  <node concept="2OqwBi" id="4OYzberckzS" role="33vP2m">
+                    <node concept="7Obwk" id="4OYzberckq9" role="2Oq$k0" />
+                    <node concept="2DeJnW" id="4OYzberckXj" role="2OqNvi">
+                      <ref role="1_rbq0" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="4OYzbercll8" role="3cqZAp">
+                <node concept="2OqwBi" id="4OYzberclO7" role="3clFbG">
+                  <node concept="2OqwBi" id="4OYzberclwu" role="2Oq$k0">
+                    <node concept="37vLTw" id="4OYzbercll6" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4OYzbercknz" resolve="mapElement" />
+                    </node>
+                    <node concept="3TrEf2" id="4OYzberclIP" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
+                    </node>
+                  </node>
+                  <node concept="2oxUTD" id="4OYzberclV1" role="2OqNvi">
+                    <node concept="7Obwk" id="4OYzberclWL" role="2oxUTC" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="5qYvgS58Bbz" role="3cqZAp">
+                <node concept="3cpWsn" id="5qYvgS58Bb$" role="3cpWs9">
+                  <property role="TrG5h" value="param" />
+                  <node concept="3Tqbb2" id="5qYvgS58B6H" role="1tU5fm">
+                    <ref role="ehGHo" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+                  </node>
+                  <node concept="2OqwBi" id="5qYvgS58Bb_" role="33vP2m">
+                    <node concept="2OqwBi" id="5qYvgS58BbA" role="2Oq$k0">
+                      <node concept="2OqwBi" id="5qYvgS58BbB" role="2Oq$k0">
+                        <node concept="2OqwBi" id="5qYvgS58BbC" role="2Oq$k0">
+                          <node concept="37vLTw" id="5qYvgS58BbD" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4OYzbercknz" resolve="mapElement" />
+                          </node>
+                          <node concept="3TrEf2" id="5qYvgS58BbE" role="2OqNvi">
+                            <ref role="3Tt5mk" to="pkab:4OYzberaMVq" resolve="closure" />
+                          </node>
+                        </node>
+                        <node concept="2DeJnY" id="5qYvgS58BbF" role="2OqNvi">
+                          <ref role="1A9B2P" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                        </node>
+                      </node>
+                      <node concept="3Tsc0h" id="5qYvgS58BbG" role="2OqNvi">
+                        <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                      </node>
+                    </node>
+                    <node concept="2DeJg1" id="5qYvgS58BbH" role="2OqNvi">
+                      <ref role="1A0vxQ" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="4OYzbercmsb" role="3cqZAp">
+                <node concept="2OqwBi" id="4OYzbercGHG" role="3clFbG">
+                  <node concept="2OqwBi" id="4OYzbercFul" role="2Oq$k0">
+                    <node concept="37vLTw" id="5qYvgS58BbI" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5qYvgS58Bb$" resolve="param" />
+                    </node>
+                    <node concept="3TrcHB" id="4OYzbercGeQ" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                  <node concept="tyxLq" id="4OYzbercHg4" role="2OqNvi">
+                    <node concept="Xl_RD" id="4OYzbercHg$" role="tz02z">
+                      <property role="Xl_RC" value="key" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5qYvgS58DGD" role="3cqZAp">
+                <node concept="2OqwBi" id="5qYvgS58EXG" role="3clFbG">
+                  <node concept="2OqwBi" id="5qYvgS58E6d" role="2Oq$k0">
+                    <node concept="37vLTw" id="5qYvgS58DGB" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5qYvgS58Bb$" resolve="param" />
+                    </node>
+                    <node concept="3TrEf2" id="5qYvgS58EL0" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tpee:4VkOLwjf83e" resolve="type" />
+                    </node>
+                  </node>
+                  <node concept="2oxUTD" id="5qYvgS58Fyi" role="2OqNvi">
+                    <node concept="2OqwBi" id="5qYvgS58Gk4" role="2oxUTC">
+                      <node concept="2OqwBi" id="5qYvgS58FMJ" role="2Oq$k0">
+                        <node concept="3yx0qK" id="5qYvgS58F$b" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4OYzbercgmO" resolve="mapType" />
+                        </node>
+                        <node concept="3TrEf2" id="5qYvgS58GfI" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tp2q:hrrvQaC" resolve="keyType" />
+                        </node>
+                      </node>
+                      <node concept="1$rogu" id="5qYvgS58Gp7" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="1wEcoXjJzvG" role="3cqZAp">
+                <node concept="2OqwBi" id="1wEcoXjJzvB" role="3clFbG">
+                  <node concept="37vLTw" id="1wEcoXjJzv$" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4OYzbercknz" resolve="mapElement" />
+                  </node>
+                  <node concept="1OKiuA" id="1wEcoXjJzvC" role="2OqNvi">
+                    <node concept="1Q80Hx" id="1wEcoXjJzvD" role="lBI5i" />
+                    <node concept="2B6iha" id="1wEcoXjJzvE" role="lGT1i">
+                      <property role="1lyBwo" value="59pBc0SIIVt/mostRelevant" />
+                    </node>
+                    <node concept="3cmrfG" id="1wEcoXjJzvF" role="3dN3m$">
+                      <property role="3cmrfH" value="-1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1FNNb$" id="4OYzberchh2" role="1FNMel">
+            <ref role="1FNNbB" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
+          </node>
+          <node concept="3cqGtN" id="4OYzberchtl" role="2jZA2a">
+            <node concept="3cqJkl" id="4OYzberchtm" role="3cqGtW">
+              <node concept="3clFbS" id="4OYzberchtn" role="2VODD2">
+                <node concept="3clFbF" id="4OYzberchz0" role="3cqZAp">
+                  <node concept="Xl_RD" id="4OYzberchyZ" role="3clFbG">
+                    <property role="Xl_RC" value="get or put" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.intentions.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.intentions.mps
@@ -1,0 +1,435 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:c3ceb8a1-2ec2-41e2-af07-d63612cf6f77(de.itemis.mps.baseLanguageExtensions.intentions)">
+  <persistence version="9" />
+  <languages>
+    <use id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" version="1" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="tp2c" ref="r:00000000-0000-4000-0000-011c89590338(jetbrains.mps.baseLanguage.closures.structure)" />
+    <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" />
+    <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1194033889146" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1XNTG" />
+    </language>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="3547227755871693971" name="jetbrains.mps.lang.editor.structure.PredefinedSelector" flags="ng" index="2B6iha">
+        <property id="2162403111523065396" name="cellId" index="1lyBwo" />
+      </concept>
+      <concept id="3647146066980922272" name="jetbrains.mps.lang.editor.structure.SelectInEditorOperation" flags="nn" index="1OKiuA">
+        <child id="1948540814633499358" name="editorContext" index="lBI5i" />
+        <child id="1948540814635895774" name="cellSelector" index="lGT1i" />
+        <child id="3604384757217586546" name="selectionStart" index="3dN3m$" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+    </language>
+    <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
+      <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
+      <concept id="1192794782375" name="jetbrains.mps.lang.intentions.structure.DescriptionBlock" flags="in" index="2S6ZIM" />
+      <concept id="1192795771125" name="jetbrains.mps.lang.intentions.structure.IsApplicableBlock" flags="in" index="2SaL7w" />
+      <concept id="1192795911897" name="jetbrains.mps.lang.intentions.structure.ExecuteBlock" flags="in" index="2Sbjvc" />
+      <concept id="1192796902958" name="jetbrains.mps.lang.intentions.structure.ConceptFunctionParameter_node" flags="nn" index="2Sf5sV" />
+      <concept id="2522969319638091381" name="jetbrains.mps.lang.intentions.structure.BaseIntentionDeclaration" flags="ig" index="2ZfUlf">
+        <property id="2522969319638091386" name="isAvailableInChildNodes" index="2ZfUl0" />
+        <reference id="2522969319638198290" name="forConcept" index="2ZfgGC" />
+        <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
+        <child id="2522969319638093995" name="isApplicableFunction" index="2ZfVeh" />
+        <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
+      </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
+      <concept id="1178870617262" name="jetbrains.mps.lang.typesystem.structure.CoerceExpression" flags="nn" index="1UaxmW">
+        <child id="1178870894644" name="pattern" index="1Ub_4A" />
+        <child id="1178870894645" name="nodeToCoerce" index="1Ub_4B" />
+      </concept>
+      <concept id="1178871491133" name="jetbrains.mps.lang.typesystem.structure.CoerceStrongExpression" flags="nn" index="1UdQGJ" />
+      <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
+        <reference id="1174642800329" name="concept" index="1YaFvo" />
+      </concept>
+    </language>
+    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="767145758118872833" name="jetbrains.mps.lang.actions.structure.NF_LinkList_AddNewChildOperation" flags="nn" index="2DeJg1" />
+      <concept id="767145758118872830" name="jetbrains.mps.lang.actions.structure.NF_Link_SetNewChildOperation" flags="nn" index="2DeJnY" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
+        <child id="1140725362529" name="linkTarget" index="2oxUTC" />
+      </concept>
+      <concept id="1138661924179" name="jetbrains.mps.lang.smodel.structure.Property_SetOperation" flags="nn" index="tyxLq">
+        <child id="1138662048170" name="value" index="tz02z" />
+      </concept>
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC">
+        <reference id="1139880128956" name="concept" index="1A9B2P" />
+      </concept>
+      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
+        <reference id="1139877738879" name="concept" index="1A0vxQ" />
+      </concept>
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1139867745658" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithNewOperation" flags="nn" index="1_qnLN">
+        <reference id="1139867957129" name="concept" index="1_rbq0" />
+      </concept>
+      <concept id="1172326502327" name="jetbrains.mps.lang.smodel.structure.Concept_IsExactlyOperation" flags="nn" index="3O6GUB">
+        <child id="1206733650006" name="conceptArgument" index="3QVz_e" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2S6QgY" id="4OYzberd81d">
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <property role="TrG5h" value="ConvertToGet" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
+    <node concept="2S6ZIM" id="4OYzberd81e" role="2ZfVej">
+      <node concept="3clFbS" id="4OYzberd81f" role="2VODD2">
+        <node concept="3clFbF" id="4OYzberd9$q" role="3cqZAp">
+          <node concept="Xl_RD" id="4OYzberd9$p" role="3clFbG">
+            <property role="Xl_RC" value="Convert to strict 'get'" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="4OYzberd81g" role="2ZfgGD">
+      <node concept="3clFbS" id="4OYzberd81h" role="2VODD2">
+        <node concept="3cpWs8" id="4OYzberdatL" role="3cqZAp">
+          <node concept="3cpWsn" id="4OYzberdatM" role="3cpWs9">
+            <property role="TrG5h" value="replacement" />
+            <node concept="3Tqbb2" id="4OYzberdato" role="1tU5fm">
+              <ref role="ehGHo" to="tp2q:hrEllC_" resolve="MapElement" />
+            </node>
+            <node concept="2OqwBi" id="4OYzberdatN" role="33vP2m">
+              <node concept="2Sf5sV" id="4OYzberdatO" role="2Oq$k0" />
+              <node concept="1_qnLN" id="4OYzberdatP" role="2OqNvi">
+                <ref role="1_rbq0" to="tp2q:hrEllC_" resolve="MapElement" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4OYzberd9IH" role="3cqZAp">
+          <node concept="37vLTI" id="4OYzberdb4i" role="3clFbG">
+            <node concept="2OqwBi" id="4OYzberdbh5" role="37vLTx">
+              <node concept="2Sf5sV" id="4OYzberdb72" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4OYzberdbt0" role="2OqNvi">
+                <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4OYzberdaDd" role="37vLTJ">
+              <node concept="37vLTw" id="4OYzberdatQ" role="2Oq$k0">
+                <ref role="3cqZAo" node="4OYzberdatM" resolve="replacement" />
+              </node>
+              <node concept="3TrEf2" id="4OYzberdaRi" role="2OqNvi">
+                <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4OYzberdbw_" role="3cqZAp">
+          <node concept="37vLTI" id="4OYzberdchc" role="3clFbG">
+            <node concept="2OqwBi" id="4OYzberdcrG" role="37vLTx">
+              <node concept="2Sf5sV" id="4OYzberdchD" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4OYzberdcBf" role="2OqNvi">
+                <ref role="3Tt5mk" to="tp2q:hrElVp8" resolve="key" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4OYzberdbQ9" role="37vLTJ">
+              <node concept="37vLTw" id="4OYzberdbwz" role="2Oq$k0">
+                <ref role="3cqZAo" node="4OYzberdatM" resolve="replacement" />
+              </node>
+              <node concept="3TrEf2" id="4OYzberdc4e" role="2OqNvi">
+                <ref role="3Tt5mk" to="tp2q:hrElVp8" resolve="key" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="4OYzberdcDT">
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <property role="TrG5h" value="ConvertToGetOrCompute" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="tp2q:hrEllC_" resolve="MapElement" />
+    <node concept="2S6ZIM" id="4OYzberdcDU" role="2ZfVej">
+      <node concept="3clFbS" id="4OYzberdcDV" role="2VODD2">
+        <node concept="3clFbF" id="4OYzberdcKY" role="3cqZAp">
+          <node concept="Xl_RD" id="4OYzberdcKX" role="3clFbG">
+            <property role="Xl_RC" value="Convert to 'get or put'" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="4OYzberdcDW" role="2ZfgGD">
+      <node concept="3clFbS" id="4OYzberdcDX" role="2VODD2">
+        <node concept="3cpWs8" id="4OYzberdf$J" role="3cqZAp">
+          <node concept="3cpWsn" id="4OYzberdf$K" role="3cpWs9">
+            <property role="TrG5h" value="replacement" />
+            <node concept="3Tqbb2" id="4OYzberdf$m" role="1tU5fm">
+              <ref role="ehGHo" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
+            </node>
+            <node concept="2OqwBi" id="4OYzberdf$L" role="33vP2m">
+              <node concept="2Sf5sV" id="4OYzberdf$M" role="2Oq$k0" />
+              <node concept="1_qnLN" id="4OYzberdf$N" role="2OqNvi">
+                <ref role="1_rbq0" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4OYzberdeIp" role="3cqZAp">
+          <node concept="37vLTI" id="4OYzberdgeZ" role="3clFbG">
+            <node concept="2OqwBi" id="4OYzberdgor" role="37vLTx">
+              <node concept="2Sf5sV" id="4OYzberdgfs" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4OYzberdgAt" role="2OqNvi">
+                <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4OYzberdfLL" role="37vLTJ">
+              <node concept="37vLTw" id="4OYzberdf$O" role="2Oq$k0">
+                <ref role="3cqZAo" node="4OYzberdf$K" resolve="replacement" />
+              </node>
+              <node concept="3TrEf2" id="4OYzberdg1X" role="2OqNvi">
+                <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4OYzberdgEl" role="3cqZAp">
+          <node concept="37vLTI" id="4OYzberdgMO" role="3clFbG">
+            <node concept="2OqwBi" id="4OYzberdgQt" role="37vLTx">
+              <node concept="2Sf5sV" id="4OYzberdgND" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4OYzberdh5E" role="2OqNvi">
+                <ref role="3Tt5mk" to="tp2q:hrElVp8" resolve="key" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4OYzberdgJ2" role="37vLTJ">
+              <node concept="37vLTw" id="4OYzberdgEj" role="2Oq$k0">
+                <ref role="3cqZAo" node="4OYzberdf$K" resolve="replacement" />
+              </node>
+              <node concept="3TrEf2" id="4OYzberdgLs" role="2OqNvi">
+                <ref role="3Tt5mk" to="tp2q:hrElVp8" resolve="key" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5qYvgS57678" role="3cqZAp">
+          <node concept="3cpWsn" id="5qYvgS57679" role="3cpWs9">
+            <property role="TrG5h" value="param" />
+            <node concept="3Tqbb2" id="5qYvgS5762b" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="5qYvgS5767a" role="33vP2m">
+              <node concept="2OqwBi" id="5qYvgS5767b" role="2Oq$k0">
+                <node concept="2OqwBi" id="5qYvgS5767c" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5qYvgS5767d" role="2Oq$k0">
+                    <node concept="37vLTw" id="5qYvgS5767e" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4OYzberdf$K" resolve="replacement" />
+                    </node>
+                    <node concept="3TrEf2" id="5qYvgS5767f" role="2OqNvi">
+                      <ref role="3Tt5mk" to="pkab:4OYzberaMVq" resolve="closure" />
+                    </node>
+                  </node>
+                  <node concept="2DeJnY" id="5qYvgS5767g" role="2OqNvi">
+                    <ref role="1A9B2P" to="tp2c:htbVj4_" resolve="ClosureLiteral" />
+                  </node>
+                </node>
+                <node concept="3Tsc0h" id="5qYvgS5767h" role="2OqNvi">
+                  <ref role="3TtcxE" to="tp2c:htbW2KO" resolve="parameter" />
+                </node>
+              </node>
+              <node concept="2DeJg1" id="5qYvgS5767i" role="2OqNvi">
+                <ref role="1A0vxQ" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4OYzberh19n" role="3cqZAp">
+          <node concept="2OqwBi" id="4OYzberhnrU" role="3clFbG">
+            <node concept="2OqwBi" id="4OYzberhmak" role="2Oq$k0">
+              <node concept="37vLTw" id="5qYvgS5767j" role="2Oq$k0">
+                <ref role="3cqZAo" node="5qYvgS57679" resolve="param" />
+              </node>
+              <node concept="3TrcHB" id="4OYzberhmX2" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+            <node concept="tyxLq" id="4OYzberhoOz" role="2OqNvi">
+              <node concept="Xl_RD" id="4OYzberhoTA" role="tz02z">
+                <property role="Xl_RC" value="key" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1$qgNbtezov" role="3cqZAp">
+          <node concept="3cpWsn" id="1$qgNbtezow" role="3cpWs9">
+            <property role="TrG5h" value="mapType" />
+            <node concept="3Tqbb2" id="1$qgNbteyRc" role="1tU5fm">
+              <ref role="ehGHo" to="tp2q:hrrvAJb" resolve="MapType" />
+            </node>
+            <node concept="1UdQGJ" id="1$qgNbtezox" role="33vP2m">
+              <node concept="1YaCAy" id="1$qgNbtezoy" role="1Ub_4A">
+                <property role="TrG5h" value="mapType" />
+                <ref role="1YaFvo" to="tp2q:hrrvAJb" resolve="MapType" />
+              </node>
+              <node concept="2OqwBi" id="1$qgNbtezoz" role="1Ub_4B">
+                <node concept="2OqwBi" id="1$qgNbtezo$" role="2Oq$k0">
+                  <node concept="2Sf5sV" id="1$qgNbtezo_" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1$qgNbtezoA" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
+                  </node>
+                </node>
+                <node concept="3JvlWi" id="1$qgNbtezoB" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1$qgNbtftVo" role="3cqZAp">
+          <node concept="3clFbS" id="1$qgNbtftVq" role="3clFbx">
+            <node concept="3clFbF" id="5qYvgS576fd" role="3cqZAp">
+              <node concept="2OqwBi" id="5qYvgS5796N" role="3clFbG">
+                <node concept="2OqwBi" id="5qYvgS577xJ" role="2Oq$k0">
+                  <node concept="37vLTw" id="5qYvgS576fb" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5qYvgS57679" resolve="param" />
+                  </node>
+                  <node concept="3TrEf2" id="5qYvgS578TZ" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpee:4VkOLwjf83e" resolve="type" />
+                  </node>
+                </node>
+                <node concept="2oxUTD" id="5qYvgS579H0" role="2OqNvi">
+                  <node concept="2OqwBi" id="5qYvgS59Nnl" role="2oxUTC">
+                    <node concept="2OqwBi" id="5qYvgS59Mq_" role="2Oq$k0">
+                      <node concept="37vLTw" id="1$qgNbtezoC" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1$qgNbtezow" resolve="mapType" />
+                      </node>
+                      <node concept="3TrEf2" id="5qYvgS59N7F" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tp2q:hrrvQaC" resolve="keyType" />
+                      </node>
+                    </node>
+                    <node concept="1$rogu" id="5qYvgS59NFc" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="1$qgNbtfv75" role="3clFbw">
+            <node concept="10Nm6u" id="1$qgNbtfveX" role="3uHU7w" />
+            <node concept="37vLTw" id="1$qgNbtftZv" role="3uHU7B">
+              <ref role="3cqZAo" node="1$qgNbtezow" resolve="mapType" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1wEcoXjJzvG" role="3cqZAp">
+          <node concept="2OqwBi" id="1wEcoXjJzvB" role="3clFbG">
+            <node concept="1OKiuA" id="1wEcoXjJzvC" role="2OqNvi">
+              <node concept="1XNTG" id="4OYzberdj0$" role="lBI5i" />
+              <node concept="2B6iha" id="1wEcoXjJzvE" role="lGT1i">
+                <property role="1lyBwo" value="59pBc0SIIVt/mostRelevant" />
+              </node>
+              <node concept="3cmrfG" id="1wEcoXjJzvF" role="3dN3m$">
+                <property role="3cmrfH" value="-1" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="4OYzberdj05" role="2Oq$k0">
+              <ref role="3cqZAo" node="4OYzberdf$K" resolve="replacement" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SaL7w" id="4OYzberdcVL" role="2ZfVeh">
+      <node concept="3clFbS" id="4OYzberdcVM" role="2VODD2">
+        <node concept="3clFbF" id="4OYzberdd0Q" role="3cqZAp">
+          <node concept="2OqwBi" id="4OYzberdedv" role="3clFbG">
+            <node concept="2OqwBi" id="4OYzberddi9" role="2Oq$k0">
+              <node concept="2Sf5sV" id="4OYzberdd0P" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4OYzberddQn" role="2OqNvi" />
+            </node>
+            <node concept="3O6GUB" id="4OYzberdeB1" role="2OqNvi">
+              <node concept="chp4Y" id="4OYzberdeGq" role="3QVz_e">
+                <ref role="cht4Q" to="tp2q:hrEllC_" resolve="MapElement" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.intentions.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.intentions.mps
@@ -45,7 +45,6 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
-      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -58,10 +57,6 @@
       </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
-      </concept>
-      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1068580123160" name="condition" index="3clFbw" />
-        <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -77,7 +72,14 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
       <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
@@ -91,6 +93,15 @@
         <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
         <child id="2522969319638093995" name="isApplicableFunction" index="2ZfVeh" />
         <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
+        <child id="5764240145346688149" name="fieldDeclaration" index="1S$sla" />
+      </concept>
+    </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1213999088275" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierFieldDeclaration" flags="ig" index="2BZ0e9" />
+      <concept id="1213999117680" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierFieldAccessOperation" flags="nn" index="2BZ7hE" />
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ng" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
       </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
@@ -125,6 +136,7 @@
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
       <concept id="1139867745658" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithNewOperation" flags="nn" index="1_qnLN">
         <reference id="1139867957129" name="concept" index="1_rbq0" />
@@ -151,6 +163,14 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
   </registry>
@@ -228,6 +248,13 @@
     <property role="TrG5h" value="ConvertToGetOrCompute" />
     <property role="2ZfUl0" value="true" />
     <ref role="2ZfgGC" to="tp2q:hrEllC_" resolve="MapElement" />
+    <node concept="2BZ0e9" id="4IKgtdbNKHU" role="1S$sla">
+      <property role="TrG5h" value="mapType" />
+      <node concept="3Tm6S6" id="4IKgtdbNKHV" role="1B3o_S" />
+      <node concept="3Tqbb2" id="4IKgtdbNKNh" role="1tU5fm">
+        <ref role="ehGHo" to="tp2q:hrrvAJb" resolve="MapType" />
+      </node>
+    </node>
     <node concept="2S6ZIM" id="4OYzberdcDU" role="2ZfVej">
       <node concept="3clFbS" id="4OYzberdcDV" role="2VODD2">
         <node concept="3clFbF" id="4OYzberdcKY" role="3cqZAp">
@@ -337,61 +364,31 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="1$qgNbtezov" role="3cqZAp">
-          <node concept="3cpWsn" id="1$qgNbtezow" role="3cpWs9">
-            <property role="TrG5h" value="mapType" />
-            <node concept="3Tqbb2" id="1$qgNbteyRc" role="1tU5fm">
-              <ref role="ehGHo" to="tp2q:hrrvAJb" resolve="MapType" />
-            </node>
-            <node concept="1UdQGJ" id="1$qgNbtezox" role="33vP2m">
-              <node concept="1YaCAy" id="1$qgNbtezoy" role="1Ub_4A">
-                <property role="TrG5h" value="mapType" />
-                <ref role="1YaFvo" to="tp2q:hrrvAJb" resolve="MapType" />
+        <node concept="3clFbF" id="5qYvgS576fd" role="3cqZAp">
+          <node concept="2OqwBi" id="5qYvgS5796N" role="3clFbG">
+            <node concept="2OqwBi" id="5qYvgS577xJ" role="2Oq$k0">
+              <node concept="37vLTw" id="5qYvgS576fb" role="2Oq$k0">
+                <ref role="3cqZAo" node="5qYvgS57679" resolve="param" />
               </node>
-              <node concept="2OqwBi" id="1$qgNbtezoz" role="1Ub_4B">
-                <node concept="2OqwBi" id="1$qgNbtezo$" role="2Oq$k0">
-                  <node concept="2Sf5sV" id="1$qgNbtezo_" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="1$qgNbtezoA" role="2OqNvi">
-                    <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
-                  </node>
-                </node>
-                <node concept="3JvlWi" id="1$qgNbtezoB" role="2OqNvi" />
+              <node concept="3TrEf2" id="5qYvgS578TZ" role="2OqNvi">
+                <ref role="3Tt5mk" to="tpee:4VkOLwjf83e" resolve="type" />
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="1$qgNbtftVo" role="3cqZAp">
-          <node concept="3clFbS" id="1$qgNbtftVq" role="3clFbx">
-            <node concept="3clFbF" id="5qYvgS576fd" role="3cqZAp">
-              <node concept="2OqwBi" id="5qYvgS5796N" role="3clFbG">
-                <node concept="2OqwBi" id="5qYvgS577xJ" role="2Oq$k0">
-                  <node concept="37vLTw" id="5qYvgS576fb" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5qYvgS57679" resolve="param" />
-                  </node>
-                  <node concept="3TrEf2" id="5qYvgS578TZ" role="2OqNvi">
-                    <ref role="3Tt5mk" to="tpee:4VkOLwjf83e" resolve="type" />
-                  </node>
-                </node>
-                <node concept="2oxUTD" id="5qYvgS579H0" role="2OqNvi">
-                  <node concept="2OqwBi" id="5qYvgS59Nnl" role="2oxUTC">
-                    <node concept="2OqwBi" id="5qYvgS59Mq_" role="2Oq$k0">
-                      <node concept="37vLTw" id="1$qgNbtezoC" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1$qgNbtezow" resolve="mapType" />
-                      </node>
-                      <node concept="3TrEf2" id="5qYvgS59N7F" role="2OqNvi">
-                        <ref role="3Tt5mk" to="tp2q:hrrvQaC" resolve="keyType" />
-                      </node>
+            <node concept="2oxUTD" id="5qYvgS579H0" role="2OqNvi">
+              <node concept="2OqwBi" id="5qYvgS59Nnl" role="2oxUTC">
+                <node concept="2OqwBi" id="5qYvgS59Mq_" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4IKgtdbNLPd" role="2Oq$k0">
+                    <node concept="2WthIp" id="4IKgtdbNLKz" role="2Oq$k0" />
+                    <node concept="2BZ7hE" id="4IKgtdbNLXh" role="2OqNvi">
+                      <ref role="2WH_rO" node="4IKgtdbNKHU" resolve="mapType" />
                     </node>
-                    <node concept="1$rogu" id="5qYvgS59NFc" role="2OqNvi" />
+                  </node>
+                  <node concept="3TrEf2" id="5qYvgS59N7F" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tp2q:hrrvQaC" resolve="keyType" />
                   </node>
                 </node>
+                <node concept="1$rogu" id="5qYvgS59NFc" role="2OqNvi" />
               </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="1$qgNbtfv75" role="3clFbw">
-            <node concept="10Nm6u" id="1$qgNbtfveX" role="3uHU7w" />
-            <node concept="37vLTw" id="1$qgNbtftZv" role="3uHU7B">
-              <ref role="3cqZAo" node="1$qgNbtezow" resolve="mapType" />
             </node>
           </node>
         </node>
@@ -415,15 +412,97 @@
     </node>
     <node concept="2SaL7w" id="4OYzberdcVL" role="2ZfVeh">
       <node concept="3clFbS" id="4OYzberdcVM" role="2VODD2">
-        <node concept="3clFbF" id="4OYzberdd0Q" role="3cqZAp">
-          <node concept="2OqwBi" id="4OYzberdedv" role="3clFbG">
-            <node concept="2OqwBi" id="4OYzberddi9" role="2Oq$k0">
-              <node concept="2Sf5sV" id="4OYzberdd0P" role="2Oq$k0" />
-              <node concept="2yIwOk" id="4OYzberddQn" role="2OqNvi" />
+        <node concept="3SKdUt" id="4IKgtdbOxOp" role="3cqZAp">
+          <node concept="1PaTwC" id="4IKgtdbOxOq" role="1aUNEU">
+            <node concept="3oM_SD" id="4IKgtdbOxPN" role="1PaTwD">
+              <property role="3oM_SC" value="typesystem" />
             </node>
-            <node concept="3O6GUB" id="4OYzberdeB1" role="2OqNvi">
-              <node concept="chp4Y" id="4OYzberdeGq" role="3QVz_e">
-                <ref role="cht4Q" to="tp2q:hrEllC_" resolve="MapElement" />
+            <node concept="3oM_SD" id="4IKgtdbOxPY" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="4IKgtdbOxQ2" role="1PaTwD">
+              <property role="3oM_SC" value="only" />
+            </node>
+            <node concept="3oM_SD" id="4IKgtdbOxQa" role="1PaTwD">
+              <property role="3oM_SC" value="available" />
+            </node>
+            <node concept="3oM_SD" id="4IKgtdbOxQl" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="4IKgtdbOxQp" role="1PaTwD">
+              <property role="3oM_SC" value="preparation" />
+            </node>
+            <node concept="3oM_SD" id="4IKgtdbOxQA" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="4IKgtdbOxQE" role="1PaTwD">
+              <property role="3oM_SC" value="an" />
+            </node>
+            <node concept="3oM_SD" id="4IKgtdbOxQI" role="1PaTwD">
+              <property role="3oM_SC" value="action/intention," />
+            </node>
+            <node concept="3oM_SD" id="4IKgtdbOxR7" role="1PaTwD">
+              <property role="3oM_SC" value="but" />
+            </node>
+            <node concept="3oM_SD" id="4IKgtdbOxRc" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="4IKgtdbOxRh" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="4IKgtdbO_jD" role="1PaTwD">
+              <property role="3oM_SC" value="'execute'" />
+            </node>
+            <node concept="3oM_SD" id="4IKgtdbOxRz" role="1PaTwD">
+              <property role="3oM_SC" value="itself" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4IKgtdbNKZv" role="3cqZAp">
+          <node concept="37vLTI" id="4IKgtdbNL$l" role="3clFbG">
+            <node concept="1UdQGJ" id="4IKgtdbOxAw" role="37vLTx">
+              <node concept="1YaCAy" id="4IKgtdbOxAx" role="1Ub_4A">
+                <property role="TrG5h" value="mapType" />
+                <ref role="1YaFvo" to="tp2q:hrrvAJb" resolve="MapType" />
+              </node>
+              <node concept="2OqwBi" id="4IKgtdbOxAy" role="1Ub_4B">
+                <node concept="2OqwBi" id="4IKgtdbOxAz" role="2Oq$k0">
+                  <node concept="2Sf5sV" id="4IKgtdbOxA$" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4IKgtdbOxA_" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
+                  </node>
+                </node>
+                <node concept="3JvlWi" id="4IKgtdbOxAA" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4IKgtdbNL8T" role="37vLTJ">
+              <node concept="2WthIp" id="4IKgtdbNKZt" role="2Oq$k0" />
+              <node concept="2BZ7hE" id="4IKgtdbNLkR" role="2OqNvi">
+                <ref role="2WH_rO" node="4IKgtdbNKHU" resolve="mapType" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4OYzberdd0Q" role="3cqZAp">
+          <node concept="1Wc70l" id="4IKgtdbOymC" role="3clFbG">
+            <node concept="2OqwBi" id="4IKgtdbOz5L" role="3uHU7w">
+              <node concept="2OqwBi" id="4IKgtdbOyHO" role="2Oq$k0">
+                <node concept="2WthIp" id="4IKgtdbOyzY" role="2Oq$k0" />
+                <node concept="2BZ7hE" id="4IKgtdbOyPS" role="2OqNvi">
+                  <ref role="2WH_rO" node="4IKgtdbNKHU" resolve="mapType" />
+                </node>
+              </node>
+              <node concept="3x8VRR" id="4IKgtdbO$0c" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="4OYzberdedv" role="3uHU7B">
+              <node concept="2OqwBi" id="4OYzberddi9" role="2Oq$k0">
+                <node concept="2Sf5sV" id="4OYzberdd0P" role="2Oq$k0" />
+                <node concept="2yIwOk" id="4OYzberddQn" role="2OqNvi" />
+              </node>
+              <node concept="3O6GUB" id="4OYzberdeB1" role="2OqNvi">
+                <node concept="chp4Y" id="4OYzberdeGq" role="3QVz_e">
+                  <ref role="cht4Q" to="tp2q:hrEllC_" resolve="MapElement" />
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
@@ -209,5 +209,27 @@
       <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
     </node>
   </node>
+  <node concept="1TIwiD" id="3bMhTtR51d8">
+    <property role="EcuMT" value="3671075362123813704" />
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <property role="TrG5h" value="GetOrComputeOperation" />
+    <property role="34LRSv" value="getOrPut" />
+    <property role="R4oN_" value="get or put" />
+    <ref role="1TJDcQ" to="tp2q:huID7Cm" resolve="MapOperation" />
+    <node concept="1TJgyj" id="3bMhTtR51da" role="1TKVEi">
+      <property role="IQ2ns" value="3671075362123813706" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="key" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
+    </node>
+    <node concept="1TJgyj" id="3bMhTtR51d9" role="1TKVEi">
+      <property role="IQ2ns" value="3671075362123813705" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="closure" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
@@ -194,5 +194,20 @@
     <property role="R4oN_" value="smart closure parameter" />
     <ref role="1TJDcQ" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
   </node>
+  <node concept="1TIwiD" id="4OYzberaMVo">
+    <property role="EcuMT" value="5566040892506844888" />
+    <property role="TrG5h" value="MapElementOrCompute" />
+    <property role="34LRSv" value="[ =&gt;" />
+    <property role="R4oN_" value="get or put" />
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <ref role="1TJDcQ" to="tp2q:hrEllC_" resolve="MapElement" />
+    <node concept="1TJgyj" id="4OYzberaMVq" role="1TKVEi">
+      <property role="IQ2ns" value="5566040892506844890" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="closure" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
@@ -7,9 +7,9 @@
   </languages>
   <imports>
     <import index="tp2v" ref="r:00000000-0000-4000-0000-011c8959032b(jetbrains.mps.baseLanguage.collections.typesystem)" />
+    <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
     <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
-    <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" implicit="true" />
     <import index="tpek" ref="r:00000000-0000-4000-0000-011c895902c0(jetbrains.mps.baseLanguage.behavior)" implicit="true" />
     <import index="tp2c" ref="r:00000000-0000-4000-0000-011c89590338(jetbrains.mps.baseLanguage.closures.structure)" implicit="true" />
   </imports>
@@ -1358,6 +1358,91 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="1YbPZF" id="4OYzberaNWH">
+    <property role="TrG5h" value="typeof_MapElementOrCompute" />
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <node concept="3clFbS" id="4OYzberaNWI" role="18ibNy">
+      <node concept="1ZxtTE" id="hrNlNIx" role="3cqZAp">
+        <property role="TrG5h" value="keyType" />
+      </node>
+      <node concept="1ZxtTE" id="hrNlPmM" role="3cqZAp">
+        <property role="TrG5h" value="valueType" />
+      </node>
+      <node concept="1ZoDhX" id="6DFN5BsVqHA" role="3cqZAp">
+        <property role="3wDh2S" value="false" />
+        <node concept="mw_s8" id="hrNm7fh" role="1ZfhKB">
+          <node concept="1Z2H0r" id="hrNlSnX" role="mwGJk">
+            <node concept="2OqwBi" id="hxx$K0Y" role="1Z2MuG">
+              <node concept="1YBJjd" id="hrNlVuI" role="2Oq$k0">
+                <ref role="1YBMHb" node="4OYzberaNWK" resolve="mapElementOrCompute" />
+              </node>
+              <node concept="3TrEf2" id="hrNm2yV" role="2OqNvi">
+                <ref role="3Tt5mk" to="tp2q:hrElQF7" resolve="map" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hrNm9fW" role="1ZfhK$">
+          <node concept="2c44tf" id="hrNm9fX" role="mwGJk">
+            <node concept="3rvAFt" id="hrNmbx0" role="2c44tc">
+              <node concept="33vP2l" id="hrNmbx1" role="3rvQeY">
+                <node concept="2c44te" id="hrNmcnZ" role="lGtFl">
+                  <node concept="1Z$b5t" id="hrNmewg" role="2c44t1">
+                    <ref role="1Z$eMM" node="hrNlNIx" resolve="keyType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="33vP2l" id="hrNmbx2" role="3rvSg0">
+                <node concept="2c44te" id="hrNmfgQ" role="lGtFl">
+                  <node concept="1Z$b5t" id="hrNmfNj" role="2c44t1">
+                    <ref role="1Z$eMM" node="hrNlPmM" resolve="valueType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1ZobV4" id="4OYzberaQfJ" role="3cqZAp">
+        <node concept="mw_s8" id="4OYzberaQfV" role="1ZfhKB">
+          <node concept="2c44tf" id="4OYzberaQfR" role="mwGJk">
+            <node concept="1ajhzC" id="4OYzberaQgV" role="2c44tc">
+              <node concept="33vP2l" id="4OYzberaQiv" role="1ajw0F">
+                <node concept="2c44te" id="4OYzberaQjN" role="lGtFl">
+                  <node concept="1Z$b5t" id="4OYzberaQjV" role="2c44t1">
+                    <ref role="1Z$eMM" node="hrNlNIx" resolve="keyType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="33vP2l" id="4OYzberaQgW" role="1ajl9A">
+                <node concept="2c44te" id="4OYzberaQig" role="lGtFl">
+                  <node concept="1Z$b5t" id="4OYzberaQio" role="2c44t1">
+                    <ref role="1Z$eMM" node="hrNlPmM" resolve="valueType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="4OYzberaQfM" role="1ZfhK$">
+          <node concept="1Z2H0r" id="4OYzberaP96" role="mwGJk">
+            <node concept="2OqwBi" id="4OYzberaPng" role="1Z2MuG">
+              <node concept="1YBJjd" id="4OYzberaPaZ" role="2Oq$k0">
+                <ref role="1YBMHb" node="4OYzberaNWK" resolve="mapElementOrCompute" />
+              </node>
+              <node concept="3TrEf2" id="4OYzberaPUB" role="2OqNvi">
+                <ref role="3Tt5mk" to="pkab:4OYzberaMVq" resolve="closure" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="4OYzberaNWK" role="1YuTPh">
+      <property role="TrG5h" value="mapElementOrCompute" />
+      <ref role="1YaFvo" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
     </node>
   </node>
 </model>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
@@ -8,7 +8,7 @@
   <imports>
     <import index="tp2v" ref="r:00000000-0000-4000-0000-011c8959032b(jetbrains.mps.baseLanguage.collections.typesystem)" />
     <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" />
-    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="pkab" ref="r:63a6d225-96f6-404a-a9eb-033dc2f950a1(de.itemis.mps.baseLanguageExtensions.structure)" implicit="true" />
     <import index="tpek" ref="r:00000000-0000-4000-0000-011c895902c0(jetbrains.mps.baseLanguage.behavior)" implicit="true" />
     <import index="tp2c" ref="r:00000000-0000-4000-0000-011c89590338(jetbrains.mps.baseLanguage.closures.structure)" implicit="true" />
@@ -1443,6 +1443,118 @@
     <node concept="1YaCAy" id="4OYzberaNWK" role="1YuTPh">
       <property role="TrG5h" value="mapElementOrCompute" />
       <ref role="1YaFvo" to="pkab:4OYzberaMVo" resolve="MapElementOrCompute" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="7kYXsDnjYrk">
+    <property role="TrG5h" value="typeof_GetOrComputeOperation" />
+    <property role="3GE5qa" value="mapGetOrPutOperation" />
+    <node concept="3clFbS" id="7kYXsDnjYrl" role="18ibNy">
+      <node concept="1ZxtTE" id="7kYXsDnjYrr" role="3cqZAp">
+        <property role="TrG5h" value="keyType" />
+      </node>
+      <node concept="1ZxtTE" id="7kYXsDnjYrs" role="3cqZAp">
+        <property role="TrG5h" value="valueType" />
+      </node>
+      <node concept="1ZoDhX" id="7kYXsDnjYr$" role="3cqZAp">
+        <property role="3wDh2S" value="false" />
+        <node concept="mw_s8" id="7kYXsDnjYr_" role="1ZfhKB">
+          <node concept="1Z2H0r" id="7kYXsDnjYrA" role="mwGJk">
+            <node concept="2OqwBi" id="7kYXsDnjYrB" role="1Z2MuG">
+              <node concept="1PxgMI" id="7kYXsDnjZ8Q" role="2Oq$k0">
+                <node concept="chp4Y" id="7kYXsDnjZ9u" role="3oSUPX">
+                  <ref role="cht4Q" to="tpee:hqOqwz4" resolve="DotExpression" />
+                </node>
+                <node concept="2OqwBi" id="7kYXsDnjYHH" role="1m5AlR">
+                  <node concept="1YBJjd" id="7kYXsDnjYrC" role="2Oq$k0">
+                    <ref role="1YBMHb" node="7kYXsDnjYrn" resolve="getOrComputeOperation" />
+                  </node>
+                  <node concept="1mfA1w" id="7kYXsDnjYZB" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="3TrEf2" id="7kYXsDnjZTQ" role="2OqNvi">
+                <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="7kYXsDnjYrE" role="1ZfhK$">
+          <node concept="2c44tf" id="7kYXsDnjYrF" role="mwGJk">
+            <node concept="3rvAFt" id="7kYXsDnjYrG" role="2c44tc">
+              <node concept="33vP2l" id="7kYXsDnjYrH" role="3rvQeY">
+                <node concept="2c44te" id="7kYXsDnjYrI" role="lGtFl">
+                  <node concept="1Z$b5t" id="7kYXsDnjYrJ" role="2c44t1">
+                    <ref role="1Z$eMM" node="7kYXsDnjYrr" resolve="keyType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="33vP2l" id="7kYXsDnjYrK" role="3rvSg0">
+                <node concept="2c44te" id="7kYXsDnjYrL" role="lGtFl">
+                  <node concept="1Z$b5t" id="7kYXsDnjYrM" role="2c44t1">
+                    <ref role="1Z$eMM" node="7kYXsDnjYrs" resolve="valueType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1ZobV4" id="7kYXsDnk1le" role="3cqZAp">
+        <node concept="mw_s8" id="7kYXsDnk1ll" role="1ZfhK$">
+          <node concept="1Z2H0r" id="7kYXsDnk1lh" role="mwGJk">
+            <node concept="2OqwBi" id="7kYXsDnk1wn" role="1Z2MuG">
+              <node concept="1YBJjd" id="7kYXsDnk1lz" role="2Oq$k0">
+                <ref role="1YBMHb" node="7kYXsDnjYrn" resolve="getOrComputeOperation" />
+              </node>
+              <node concept="3TrEf2" id="7kYXsDnk1Lc" role="2OqNvi">
+                <ref role="3Tt5mk" to="pkab:3bMhTtR51da" resolve="key" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="7kYXsDnk1Mr" role="1ZfhKB">
+          <node concept="1Z$b5t" id="7kYXsDnkbbu" role="mwGJk">
+            <ref role="1Z$eMM" node="7kYXsDnjYrr" resolve="keyType" />
+          </node>
+        </node>
+      </node>
+      <node concept="1ZobV4" id="7kYXsDnk04T" role="3cqZAp">
+        <node concept="mw_s8" id="7kYXsDnk050" role="1ZfhK$">
+          <node concept="1Z2H0r" id="7kYXsDnk04W" role="mwGJk">
+            <node concept="2OqwBi" id="7kYXsDnk0g2" role="1Z2MuG">
+              <node concept="1YBJjd" id="7kYXsDnk05e" role="2Oq$k0">
+                <ref role="1YBMHb" node="7kYXsDnjYrn" resolve="getOrComputeOperation" />
+              </node>
+              <node concept="3TrEf2" id="7kYXsDnk0OP" role="2OqNvi">
+                <ref role="3Tt5mk" to="pkab:3bMhTtR51d9" resolve="closure" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="7kYXsDnk0RU" role="1ZfhKB">
+          <node concept="2c44tf" id="7kYXsDnk0S2" role="mwGJk">
+            <node concept="1ajhzC" id="7kYXsDnk0S3" role="2c44tc">
+              <node concept="33vP2l" id="7kYXsDnk0S4" role="1ajw0F">
+                <node concept="2c44te" id="7kYXsDnk0S5" role="lGtFl">
+                  <node concept="1Z$b5t" id="7kYXsDnk0S6" role="2c44t1">
+                    <ref role="1Z$eMM" node="7kYXsDnjYrr" resolve="keyType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="33vP2l" id="7kYXsDnk0S7" role="1ajl9A">
+                <node concept="2c44te" id="7kYXsDnk0S8" role="lGtFl">
+                  <node concept="1Z$b5t" id="7kYXsDnk0S9" role="2c44t1">
+                    <ref role="1Z$eMM" node="7kYXsDnjYrs" resolve="valueType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7kYXsDnjYrn" role="1YuTPh">
+      <property role="TrG5h" value="getOrComputeOperation" />
+      <ref role="1YaFvo" to="pkab:3bMhTtR51d8" resolve="GetOrComputeOperation" />
     </node>
   </node>
 </model>


### PR DESCRIPTION
## Name
getOrPut for maps (`map[key, (k) => fallback]`)

## Operation Type
Expression

## Use Case
When you use maps in MPS to collect values associated with keys, and if you aren't sure if a key you would use to access the map is already associated with anything, then it can be a bit verbose to either check for the presence of a value first, or do a cast to the underlying Java-types in order to use convenience methods that already exist on that level.

To assist in these situations the mentioned Java-Map-method - to query a key and if absent initialize the mapping with a provided value and return either the already existing value or the newly added one - was added to the MPS-collection abstraction level in form of an alternative MapElement (the `map[key]` syntax), that makes this Java-method accessible from within pure MPS base Language code.

## Comments
This PR also supplies two intentions that help migrating from one style of map-access to the other. But in the case that you want to convert a classical 'get' to the 'getOrPut' syntax, then the intention will not be able to pre-set the type of the closure for MPS-internal reasons I wasn't able to figure out and solve.