### PR TITLE
Add toMap operation to new language baseLanguageExtensions

### DIFF
--- a/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/models/de.itemis.mps.baseLanguageExtensions.runtime.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.runtime/models/de.itemis.mps.baseLanguageExtensions.runtime.mps
@@ -93,6 +93,7 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -152,6 +153,11 @@
       <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
@@ -228,9 +234,17 @@
         <child id="1197683466920" name="keyType" index="3rvQeY" />
         <child id="1197683475734" name="valueType" index="3rvSg0" />
       </concept>
+      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
+        <child id="1197687026896" name="keyType" index="3rHrn6" />
+        <child id="1197687035757" name="valueType" index="3rHtpV" />
+      </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
+        <child id="1197932505799" name="map" index="3ElQJh" />
+        <child id="1197932525128" name="key" index="3ElVtu" />
+      </concept>
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
@@ -1271,6 +1285,419 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="2oJmO5LUej3" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="7BsoQawA4aD">
+    <property role="TrG5h" value="ToMapOperationUtil" />
+    <node concept="2tJIrI" id="7BsoQawAjpy" role="jymVt" />
+    <node concept="2YIFZL" id="7BsoQawA4c5" role="jymVt">
+      <property role="TrG5h" value="toMapPairs" />
+      <node concept="3clFbS" id="7BsoQawA4c8" role="3clF47">
+        <node concept="3cpWs8" id="7BsoQawCiMu" role="3cqZAp">
+          <node concept="3cpWsn" id="7BsoQawCiMv" role="3cpWs9">
+            <property role="TrG5h" value="getKey" />
+            <node concept="1ajhzC" id="7BsoQawCiMp" role="1tU5fm">
+              <node concept="1LlUBW" id="7BsoQawCiMq" role="1ajw0F">
+                <node concept="16syzq" id="7BsoQawCiMr" role="1Lm7xW">
+                  <ref role="16sUi3" node="7BsoQawA4c_" resolve="K" />
+                </node>
+                <node concept="16syzq" id="7BsoQawCiMs" role="1Lm7xW">
+                  <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+                </node>
+              </node>
+              <node concept="16syzq" id="7BsoQawCiMt" role="1ajl9A">
+                <ref role="16sUi3" node="7BsoQawA4c_" resolve="K" />
+              </node>
+            </node>
+            <node concept="1bVj0M" id="7BsoQawCiMw" role="33vP2m">
+              <node concept="37vLTG" id="7BsoQawCiMx" role="1bW2Oz">
+                <property role="TrG5h" value="pair" />
+                <node concept="1LlUBW" id="7BsoQawCiMy" role="1tU5fm">
+                  <node concept="16syzq" id="7BsoQawCiMz" role="1Lm7xW">
+                    <ref role="16sUi3" node="7BsoQawA4c_" resolve="K" />
+                  </node>
+                  <node concept="16syzq" id="7BsoQawCiM$" role="1Lm7xW">
+                    <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="7BsoQawCiM_" role="1bW5cS">
+                <node concept="3clFbF" id="7BsoQawCiMA" role="3cqZAp">
+                  <node concept="1LFfDK" id="7BsoQawCiMB" role="3clFbG">
+                    <node concept="3cmrfG" id="7BsoQawCiMC" role="1LF_Uc">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                    <node concept="37vLTw" id="7BsoQawCiMD" role="1LFl5Q">
+                      <ref role="3cqZAo" node="7BsoQawCiMx" resolve="pair" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7BsoQawCksa" role="3cqZAp">
+          <node concept="3cpWsn" id="7BsoQawCksb" role="3cpWs9">
+            <property role="TrG5h" value="getValue" />
+            <node concept="1ajhzC" id="7BsoQawCks5" role="1tU5fm">
+              <node concept="1LlUBW" id="7BsoQawCks6" role="1ajw0F">
+                <node concept="16syzq" id="7BsoQawCks7" role="1Lm7xW">
+                  <ref role="16sUi3" node="7BsoQawA4c_" resolve="K" />
+                </node>
+                <node concept="16syzq" id="7BsoQawCks8" role="1Lm7xW">
+                  <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+                </node>
+              </node>
+              <node concept="16syzq" id="7BsoQawCks9" role="1ajl9A">
+                <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+              </node>
+            </node>
+            <node concept="1bVj0M" id="7BsoQawCksc" role="33vP2m">
+              <node concept="37vLTG" id="7BsoQawCksd" role="1bW2Oz">
+                <property role="TrG5h" value="pair" />
+                <node concept="1LlUBW" id="7BsoQawCkse" role="1tU5fm">
+                  <node concept="16syzq" id="7BsoQawCksf" role="1Lm7xW">
+                    <ref role="16sUi3" node="7BsoQawA4c_" resolve="K" />
+                  </node>
+                  <node concept="16syzq" id="7BsoQawCksg" role="1Lm7xW">
+                    <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="7BsoQawCksh" role="1bW5cS">
+                <node concept="3clFbF" id="7BsoQawCksi" role="3cqZAp">
+                  <node concept="1LFfDK" id="7BsoQawCksj" role="3clFbG">
+                    <node concept="37vLTw" id="7BsoQawCksk" role="1LFl5Q">
+                      <ref role="3cqZAo" node="7BsoQawCksd" resolve="pair" />
+                    </node>
+                    <node concept="3cmrfG" id="7BsoQawCksl" role="1LF_Uc">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7BsoQawClBJ" role="3cqZAp">
+          <node concept="3cpWsn" id="7BsoQawClBK" role="3cpWs9">
+            <property role="TrG5h" value="addToList" />
+            <node concept="1ajhzC" id="7BsoQawClBD" role="1tU5fm">
+              <node concept="16syzq" id="7BsoQawClBE" role="1ajw0F">
+                <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+              </node>
+              <node concept="_YKpA" id="7BsoQawClBF" role="1ajw0F">
+                <node concept="16syzq" id="7BsoQawClBG" role="_ZDj9">
+                  <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+                </node>
+              </node>
+              <node concept="_YKpA" id="7BsoQawClBH" role="1ajl9A">
+                <node concept="16syzq" id="7BsoQawClBI" role="_ZDj9">
+                  <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+                </node>
+              </node>
+            </node>
+            <node concept="1bVj0M" id="7BsoQawClBL" role="33vP2m">
+              <node concept="37vLTG" id="7BsoQawClBM" role="1bW2Oz">
+                <property role="TrG5h" value="value" />
+                <node concept="16syzq" id="7BsoQawClBN" role="1tU5fm">
+                  <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+                </node>
+              </node>
+              <node concept="37vLTG" id="7BsoQawClBO" role="1bW2Oz">
+                <property role="TrG5h" value="previousList" />
+                <node concept="_YKpA" id="7BsoQawClBP" role="1tU5fm">
+                  <node concept="16syzq" id="7BsoQawClBQ" role="_ZDj9">
+                    <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="7BsoQawClBR" role="1bW5cS">
+                <node concept="3cpWs8" id="7BsoQawClBS" role="3cqZAp">
+                  <node concept="3cpWsn" id="7BsoQawClBT" role="3cpWs9">
+                    <property role="TrG5h" value="listToUse" />
+                    <node concept="_YKpA" id="7BsoQawClBU" role="1tU5fm">
+                      <node concept="16syzq" id="7BsoQawClBV" role="_ZDj9">
+                        <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+                      </node>
+                    </node>
+                    <node concept="3K4zz7" id="7BsoQawClBW" role="33vP2m">
+                      <node concept="2ShNRf" id="7BsoQawClBX" role="3K4E3e">
+                        <node concept="Tc6Ow" id="7BsoQawClBY" role="2ShVmc">
+                          <node concept="16syzq" id="7BsoQawClBZ" role="HW$YZ">
+                            <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="7BsoQawClC0" role="3K4GZi">
+                        <ref role="3cqZAo" node="7BsoQawClBO" resolve="previousList" />
+                      </node>
+                      <node concept="3clFbC" id="7BsoQawClC1" role="3K4Cdx">
+                        <node concept="10Nm6u" id="7BsoQawClC2" role="3uHU7w" />
+                        <node concept="37vLTw" id="7BsoQawClC3" role="3uHU7B">
+                          <ref role="3cqZAo" node="7BsoQawClBO" resolve="previousList" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="7BsoQawClC4" role="3cqZAp">
+                  <node concept="2OqwBi" id="7BsoQawClC5" role="3clFbG">
+                    <node concept="37vLTw" id="7BsoQawClC6" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7BsoQawClBT" resolve="listToUse" />
+                    </node>
+                    <node concept="TSZUe" id="7BsoQawClC7" role="2OqNvi">
+                      <node concept="37vLTw" id="7BsoQawClC8" role="25WWJ7">
+                        <ref role="3cqZAo" node="7BsoQawClBM" resolve="value" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="7BsoQawClC9" role="3cqZAp">
+                  <node concept="37vLTw" id="7BsoQawClCa" role="3clFbG">
+                    <ref role="3cqZAo" node="7BsoQawClBT" resolve="listToUse" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7BsoQawBC7l" role="3cqZAp">
+          <node concept="1rXfSq" id="7BsoQawBC7j" role="3clFbG">
+            <ref role="37wK5l" node="7BsoQawB80U" resolve="toMapGeneric" />
+            <node concept="37vLTw" id="7BsoQawBC_4" role="37wK5m">
+              <ref role="3cqZAo" node="7BsoQawA4hM" resolve="seqOfPairs" />
+            </node>
+            <node concept="37vLTw" id="7BsoQawCiME" role="37wK5m">
+              <ref role="3cqZAo" node="7BsoQawCiMv" resolve="function" />
+            </node>
+            <node concept="37vLTw" id="7BsoQawCksm" role="37wK5m">
+              <ref role="3cqZAo" node="7BsoQawCksb" resolve="function" />
+            </node>
+            <node concept="37vLTw" id="7BsoQawClCb" role="37wK5m">
+              <ref role="3cqZAo" node="7BsoQawClBK" resolve="function" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7BsoQawA4bS" role="1B3o_S" />
+      <node concept="16euLQ" id="7BsoQawA4c_" role="16eVyc">
+        <property role="TrG5h" value="K" />
+      </node>
+      <node concept="16euLQ" id="7BsoQawA4fy" role="16eVyc">
+        <property role="TrG5h" value="V" />
+      </node>
+      <node concept="3rvAFt" id="7BsoQawA4gc" role="3clF45">
+        <node concept="16syzq" id="7BsoQawA4gC" role="3rvQeY">
+          <ref role="16sUi3" node="7BsoQawA4c_" resolve="K" />
+        </node>
+        <node concept="_YKpA" id="7BsoQawA4h3" role="3rvSg0">
+          <node concept="16syzq" id="7BsoQawA4hu" role="_ZDj9">
+            <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7BsoQawA4hM" role="3clF46">
+        <property role="TrG5h" value="seqOfPairs" />
+        <node concept="A3Dl8" id="7BsoQawA4hK" role="1tU5fm">
+          <node concept="1LlUBW" id="7BsoQawA4im" role="A3Ik2">
+            <node concept="16syzq" id="7BsoQawA4jm" role="1Lm7xW">
+              <ref role="16sUi3" node="7BsoQawA4c_" resolve="K" />
+            </node>
+            <node concept="16syzq" id="7BsoQawA4k$" role="1Lm7xW">
+              <ref role="16sUi3" node="7BsoQawA4fy" resolve="V" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7BsoQawB6Vg" role="jymVt" />
+    <node concept="2YIFZL" id="7BsoQawB80U" role="jymVt">
+      <property role="TrG5h" value="toMapGeneric" />
+      <node concept="37vLTG" id="7BsoQawB8q9" role="3clF46">
+        <property role="TrG5h" value="seq" />
+        <node concept="A3Dl8" id="7BsoQawB8qa" role="1tU5fm">
+          <node concept="16syzq" id="7BsoQawBtxq" role="A3Ik2">
+            <ref role="16sUi3" node="7BsoQawB8ny" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7BsoQawBu61" role="3clF46">
+        <property role="TrG5h" value="getKey" />
+        <node concept="1ajhzC" id="7BsoQawBurP" role="1tU5fm">
+          <node concept="16syzq" id="7BsoQawButZ" role="1ajl9A">
+            <ref role="16sUi3" node="7BsoQawBrN7" resolve="K" />
+          </node>
+          <node concept="16syzq" id="7BsoQawBusS" role="1ajw0F">
+            <ref role="16sUi3" node="7BsoQawB8ny" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7BsoQawBux7" role="3clF46">
+        <property role="TrG5h" value="getValue" />
+        <node concept="1ajhzC" id="7BsoQawBuT5" role="1tU5fm">
+          <node concept="16syzq" id="7BsoQawBuVf" role="1ajl9A">
+            <ref role="16sUi3" node="7BsoQawB8ou" resolve="V" />
+          </node>
+          <node concept="16syzq" id="7BsoQawBuU8" role="1ajw0F">
+            <ref role="16sUi3" node="7BsoQawB8ny" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7BsoQawBuXp" role="3clF46">
+        <property role="TrG5h" value="combineValues" />
+        <node concept="1ajhzC" id="7BsoQawBvlf" role="1tU5fm">
+          <node concept="16syzq" id="7BsoQawBvpE" role="1ajl9A">
+            <ref role="16sUi3" node="7BsoQawBq4b" resolve="W" />
+          </node>
+          <node concept="16syzq" id="7BsoQawBvmi" role="1ajw0F">
+            <ref role="16sUi3" node="7BsoQawB8ou" resolve="V" />
+          </node>
+          <node concept="16syzq" id="7BsoQawBvov" role="1ajw0F">
+            <ref role="16sUi3" node="7BsoQawBq4b" resolve="W" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="7BsoQawB80X" role="3clF47">
+        <node concept="3cpWs8" id="7BsoQawB8JJ" role="3cqZAp">
+          <node concept="3cpWsn" id="7BsoQawB8JK" role="3cpWs9">
+            <property role="TrG5h" value="map" />
+            <node concept="3rvAFt" id="7BsoQawB8JL" role="1tU5fm">
+              <node concept="16syzq" id="7BsoQawB8JM" role="3rvQeY">
+                <ref role="16sUi3" node="7BsoQawBrN7" resolve="K" />
+              </node>
+              <node concept="16syzq" id="7BsoQawB_fg" role="3rvSg0">
+                <ref role="16sUi3" node="7BsoQawBq4b" resolve="W" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7BsoQawB8JP" role="33vP2m">
+              <node concept="3rGOSV" id="7BsoQawB8JQ" role="2ShVmc">
+                <node concept="16syzq" id="7BsoQawB8JR" role="3rHrn6">
+                  <ref role="16sUi3" node="7BsoQawBrN7" resolve="K" />
+                </node>
+                <node concept="16syzq" id="7BsoQawB_Rk" role="3rHtpV">
+                  <ref role="16sUi3" node="7BsoQawBq4b" resolve="W" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7BsoQawB8JU" role="3cqZAp">
+          <node concept="2OqwBi" id="7BsoQawB8JV" role="3clFbG">
+            <node concept="2es0OD" id="7BsoQawB8JX" role="2OqNvi">
+              <node concept="1bVj0M" id="7BsoQawB8JY" role="23t8la">
+                <node concept="3clFbS" id="7BsoQawB8JZ" role="1bW5cS">
+                  <node concept="3cpWs8" id="7BsoQawBxeL" role="3cqZAp">
+                    <node concept="3cpWsn" id="7BsoQawBxeM" role="3cpWs9">
+                      <property role="TrG5h" value="key" />
+                      <node concept="16syzq" id="7BsoQawBxcZ" role="1tU5fm">
+                        <ref role="16sUi3" node="7BsoQawBrN7" resolve="K" />
+                      </node>
+                      <node concept="2Sg_IR" id="7BsoQawBxeN" role="33vP2m">
+                        <node concept="37vLTw" id="7BsoQawBxeO" role="2SgG2M">
+                          <ref role="3cqZAo" node="7BsoQawBu61" resolve="getKey" />
+                        </node>
+                        <node concept="37vLTw" id="7BsoQawBxeP" role="2SgHGx">
+                          <ref role="3cqZAo" node="7BsoQawB8Km" resolve="mapping" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="7BsoQawBxZ4" role="3cqZAp">
+                    <node concept="3cpWsn" id="7BsoQawBxZ5" role="3cpWs9">
+                      <property role="TrG5h" value="value" />
+                      <node concept="16syzq" id="7BsoQawBxWd" role="1tU5fm">
+                        <ref role="16sUi3" node="7BsoQawB8ou" resolve="V" />
+                      </node>
+                      <node concept="2Sg_IR" id="7BsoQawBxZ6" role="33vP2m">
+                        <node concept="37vLTw" id="7BsoQawBxZ7" role="2SgG2M">
+                          <ref role="3cqZAo" node="7BsoQawBux7" resolve="getValue" />
+                        </node>
+                        <node concept="37vLTw" id="7BsoQawBxZ8" role="2SgHGx">
+                          <ref role="3cqZAo" node="7BsoQawB8Km" resolve="mapping" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="7BsoQawCUBg" role="3cqZAp">
+                    <node concept="3cpWsn" id="7BsoQawCUBh" role="3cpWs9">
+                      <property role="TrG5h" value="previous" />
+                      <node concept="16syzq" id="7BsoQawCUcn" role="1tU5fm">
+                        <ref role="16sUi3" node="7BsoQawBq4b" resolve="W" />
+                      </node>
+                      <node concept="3EllGN" id="7BsoQawCUBi" role="33vP2m">
+                        <node concept="37vLTw" id="7BsoQawCUBj" role="3ElVtu">
+                          <ref role="3cqZAo" node="7BsoQawBxeM" resolve="key" />
+                        </node>
+                        <node concept="37vLTw" id="7BsoQawCUBk" role="3ElQJh">
+                          <ref role="3cqZAo" node="7BsoQawB8JK" resolve="map" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="7BsoQawByAE" role="3cqZAp">
+                    <node concept="37vLTI" id="7BsoQawB$nI" role="3clFbG">
+                      <node concept="2Sg_IR" id="7BsoQawBA85" role="37vLTx">
+                        <node concept="37vLTw" id="7BsoQawBA86" role="2SgG2M">
+                          <ref role="3cqZAo" node="7BsoQawBuXp" resolve="combineValues" />
+                        </node>
+                        <node concept="37vLTw" id="7BsoQawBBaX" role="2SgHGx">
+                          <ref role="3cqZAo" node="7BsoQawBxZ5" resolve="value" />
+                        </node>
+                        <node concept="37vLTw" id="7BsoQawCUBl" role="2SgHGx">
+                          <ref role="3cqZAo" node="7BsoQawCUBh" resolve="w" />
+                        </node>
+                      </node>
+                      <node concept="3EllGN" id="7BsoQawBzg$" role="37vLTJ">
+                        <node concept="37vLTw" id="7BsoQawBzrg" role="3ElVtu">
+                          <ref role="3cqZAo" node="7BsoQawBxeM" resolve="key" />
+                        </node>
+                        <node concept="37vLTw" id="7BsoQawByAC" role="3ElQJh">
+                          <ref role="3cqZAo" node="7BsoQawB8JK" resolve="map" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="7BsoQawB8Km" role="1bW2Oz">
+                  <property role="TrG5h" value="mapping" />
+                  <node concept="2jxLKc" id="7BsoQawB8Kn" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="7BsoQawB9W$" role="2Oq$k0">
+              <ref role="3cqZAo" node="7BsoQawB8q9" resolve="seqOfMappings" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7BsoQawB8Ko" role="3cqZAp">
+          <node concept="37vLTw" id="7BsoQawB8Kp" role="3clFbG">
+            <ref role="3cqZAo" node="7BsoQawB8JK" resolve="map" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7BsoQawB7Ea" role="1B3o_S" />
+      <node concept="16euLQ" id="7BsoQawB8ny" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+      <node concept="16euLQ" id="7BsoQawBrN7" role="16eVyc">
+        <property role="TrG5h" value="K" />
+      </node>
+      <node concept="16euLQ" id="7BsoQawB8ou" role="16eVyc">
+        <property role="TrG5h" value="V" />
+      </node>
+      <node concept="16euLQ" id="7BsoQawBq4b" role="16eVyc">
+        <property role="TrG5h" value="W" />
+      </node>
+      <node concept="3rvAFt" id="7BsoQawB8pq" role="3clF45">
+        <node concept="16syzq" id="7BsoQawB8pr" role="3rvQeY">
+          <ref role="16sUi3" node="7BsoQawBrN7" resolve="K" />
+        </node>
+        <node concept="16syzq" id="7BsoQawBqVc" role="3rvSg0">
+          <ref role="16sUi3" node="7BsoQawBq4b" resolve="W" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="7BsoQawA4aE" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions.sandbox/models/de.itemis.mps.baseLanguageExtensions.sandbox.mps
@@ -143,6 +143,7 @@
       <concept id="2751518233990321721" name="de.itemis.mps.baseLanguageExtensions.structure.ApplyScopeFunctionOperation" flags="ng" index="1kbSPS" />
       <concept id="2751518233990321724" name="de.itemis.mps.baseLanguageExtensions.structure.LetScopeFunctionOperation" flags="ng" index="1kbSPX" />
       <concept id="5566040892496752333" name="de.itemis.mps.baseLanguageExtensions.structure.SmartAtomicClosureParameterDeclaration" flags="ig" index="3nFU9Y" />
+      <concept id="8781002648718701503" name="de.itemis.mps.baseLanguageExtensions.structure.ToMapOperation" flags="ng" index="3pu13t" />
       <concept id="8919968723020343837" name="de.itemis.mps.baseLanguageExtensions.structure.ForEachWithIndexOperation" flags="ng" index="1sWJ9m" />
       <concept id="8919968723020245069" name="de.itemis.mps.baseLanguageExtensions.structure.WhereWithIndexOperation" flags="ng" index="1sZn06" />
       <concept id="578371460444482140" name="de.itemis.mps.baseLanguageExtensions.structure.ElvisOperation" flags="ng" index="1w0Eer" />
@@ -1586,6 +1587,67 @@
       <node concept="3cqZAl" id="2oJmO5M1vRm" role="3clF45" />
     </node>
     <node concept="3Tm1VV" id="2oJmO5M1vQd" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="7BsoQawDymg">
+    <property role="TrG5h" value="ToMapOperationSandbox" />
+    <node concept="2YIFZL" id="7BsoQawDynE" role="jymVt">
+      <property role="TrG5h" value="usages" />
+      <node concept="3clFbS" id="7BsoQawDynH" role="3clF47">
+        <node concept="3clFbF" id="7BsoQawDyoj" role="3cqZAp">
+          <node concept="2OqwBi" id="7BsoQawDyog" role="3clFbG">
+            <node concept="10M0yZ" id="7BsoQawDyoh" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" />
+            </node>
+            <node concept="liA8E" id="7BsoQawDyoi" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.Object)" resolve="println" />
+              <node concept="2OqwBi" id="7BsoQawDw_T" role="37wK5m">
+                <node concept="2OqwBi" id="7BsoQawDw_U" role="2Oq$k0">
+                  <node concept="2ShNRf" id="7BsoQawDw_V" role="2Oq$k0">
+                    <node concept="Tc6Ow" id="7BsoQawDw_W" role="2ShVmc">
+                      <node concept="10Oyi0" id="7BsoQawDw_X" role="HW$YZ" />
+                      <node concept="3cmrfG" id="7BsoQawDw_Y" role="HW$Y0">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                      <node concept="3cmrfG" id="7BsoQawDw_Z" role="HW$Y0">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                      <node concept="3cmrfG" id="7BsoQawDwA0" role="HW$Y0">
+                        <property role="3cmrfH" value="3" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Kbfsy" id="7BsoQawDwA1" role="2OqNvi">
+                    <node concept="2hHQnJ" id="7BsoQawDwA2" role="576Qk">
+                      <node concept="2hHTnT" id="7BsoQawDwA3" role="2hHTnU">
+                        <property role="KjLWg" value="1" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3pu13t" id="7BsoQawDwA4" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="7BsoQawDz5d" role="3cqZAp">
+          <node concept="1PaTwC" id="7BsoQawDz5e" role="1aUNEU">
+            <node concept="3oM_SD" id="7BsoQawDzgc" role="1PaTwD">
+              <property role="3oM_SC" value="[1=[1," />
+            </node>
+            <node concept="3oM_SD" id="7BsoQawDzgd" role="1PaTwD">
+              <property role="3oM_SC" value="2]," />
+            </node>
+            <node concept="3oM_SD" id="7BsoQawDzge" role="1PaTwD">
+              <property role="3oM_SC" value="3=[3]]" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7BsoQawDynj" role="1B3o_S" />
+      <node concept="3cqZAl" id="7BsoQawDynw" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="7BsoQawDymh" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/generator/templates/de.itemis.mps.baseLanguageExtensions.generator.templates@generator.mps
@@ -1016,6 +1016,50 @@
         </node>
       </node>
     </node>
+    <node concept="3aamgX" id="7BsoQawDn_B" role="3acgRq">
+      <ref role="30HIoZ" to="tpee:hqOqwz4" resolve="DotExpression" />
+      <node concept="gft3U" id="7BsoQawDn_C" role="1lVwrX">
+        <node concept="2YIFZM" id="7BsoQawDos$" role="gfFT$">
+          <ref role="37wK5l" to="96gm:7BsoQawA4c5" resolve="toMapPairs" />
+          <ref role="1Pybhc" to="96gm:7BsoQawA4aD" resolve="ToMapOperationUtil" />
+          <node concept="10Nm6u" id="7BsoQawDo_$" role="37wK5m">
+            <node concept="29HgVG" id="7BsoQawDoBy" role="lGtFl">
+              <node concept="3NFfHV" id="7BsoQawDoBz" role="3NFExx">
+                <node concept="3clFbS" id="7BsoQawDoB$" role="2VODD2">
+                  <node concept="3clFbF" id="7BsoQawDoBE" role="3cqZAp">
+                    <node concept="2OqwBi" id="7BsoQawDoB_" role="3clFbG">
+                      <node concept="3TrEf2" id="7BsoQawDoBC" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+                      </node>
+                      <node concept="30H73N" id="7BsoQawDoBD" role="2Oq$k0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="7BsoQawDnAC" role="30HLyM">
+        <node concept="3clFbS" id="7BsoQawDnAD" role="2VODD2">
+          <node concept="3clFbF" id="7BsoQawDnAE" role="3cqZAp">
+            <node concept="2OqwBi" id="7BsoQawDnAF" role="3clFbG">
+              <node concept="2OqwBi" id="7BsoQawDnAG" role="2Oq$k0">
+                <node concept="30H73N" id="7BsoQawDnAH" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7BsoQawDnAI" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="7BsoQawDnAJ" role="2OqNvi">
+                <node concept="chp4Y" id="7BsoQawDopi" role="cj9EA">
+                  <ref role="cht4Q" to="pkab:7BsoQawD7eZ" resolve="ToMapOperation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="jVnub" id="54jQkZ9fKWX">
     <property role="TrG5h" value="switchClosureLiteral" />

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.editor.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.editor.mps
@@ -11,6 +11,8 @@
     <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
+    <import index="tp2u" ref="r:00000000-0000-4000-0000-011c8959032a(jetbrains.mps.baseLanguage.collections.editor)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -35,13 +37,20 @@
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
+      <concept id="1164824717996" name="jetbrains.mps.lang.editor.structure.CellMenuDescriptor" flags="ng" index="OXEIz">
+        <child id="1164824815888" name="cellMenuPart" index="OY2wv" />
+      </concept>
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
+      </concept>
+      <concept id="1164914519156" name="jetbrains.mps.lang.editor.structure.CellMenuPart_ReplaceNode_CustomNodeConcept" flags="ng" index="UkePV">
+        <reference id="1164914727930" name="replacementConcept" index="Ul1FP" />
       </concept>
       <concept id="615427434521884870" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Subconcepts" flags="ng" index="2VfDsV" />
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
       </concept>
+      <concept id="1186414860679" name="jetbrains.mps.lang.editor.structure.EditableStyleClassItem" flags="ln" index="VPxyj" />
       <concept id="1186414949600" name="jetbrains.mps.lang.editor.structure.AutoDeletableStyleClassItem" flags="ln" index="VPRnO" />
       <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
@@ -71,6 +80,9 @@
       </concept>
       <concept id="7991336459489871999" name="jetbrains.mps.lang.editor.structure.IOutputConceptSubstituteMenuPart" flags="ng" index="3EoQpk">
         <reference id="7991336459489872009" name="outputConcept" index="3EoQqy" />
+      </concept>
+      <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
+        <child id="1164826688380" name="menuDescriptor" index="P5bDN" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
@@ -436,6 +448,24 @@
         <ref role="1k5W1q" to="tpen:hFCSUmN" resolve="RightParen" />
       </node>
       <node concept="2iRfu4" id="2oJmO5M1wK5" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="7BsoQawD9Wa">
+    <ref role="1XX52x" to="pkab:7BsoQawD7eZ" resolve="ToMapOperation" />
+    <node concept="PMmxH" id="7BsoQawD9Wc" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <ref role="1k5W1q" to="tp2u:hGdPUoh" resolve="Operation" />
+      <node concept="VPxyj" id="7BsoQawD9Wd" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
+      <node concept="VPRnO" id="7BsoQawD9Wf" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
+      <node concept="OXEIz" id="7BsoQawD9Wi" role="P5bDN">
+        <node concept="UkePV" id="7BsoQawD9Wj" role="OY2wv">
+          <ref role="Ul1FP" to="tpee:hqOqG0K" resolve="IOperation" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.structure.mps
@@ -194,5 +194,12 @@
     <property role="R4oN_" value="smart closure parameter" />
     <ref role="1TJDcQ" to="tp2q:hwRh6j$" resolve="SmartClosureParameterDeclaration" />
   </node>
+  <node concept="1TIwiD" id="7BsoQawD7eZ">
+    <property role="EcuMT" value="8781002648718701503" />
+    <property role="TrG5h" value="ToMapOperation" />
+    <property role="34LRSv" value="toMap" />
+    <property role="R4oN_" value="transforms a sequence of pairs to a map" />
+    <ref role="1TJDcQ" to="tp2q:gKAMqbp" resolve="SequenceOperation" />
+  </node>
 </model>
 

--- a/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
+++ b/code/languages/de.itemis.mps.baseLanguageExtensions/models/de.itemis.mps.baseLanguageExtensions.typesystem.mps
@@ -164,6 +164,7 @@
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
@@ -187,6 +188,9 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
@@ -1358,6 +1362,141 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="1YbPZF" id="7BsoQawDan$">
+    <property role="TrG5h" value="typeof_ToMapOperation" />
+    <node concept="3clFbS" id="7BsoQawDan_" role="18ibNy">
+      <node concept="3cpWs8" id="hfqCrgq" role="3cqZAp">
+        <node concept="3cpWsn" id="hfqCrgr" role="3cpWs9">
+          <property role="TrG5h" value="input" />
+          <node concept="3Tqbb2" id="hfqCrgs" role="1tU5fm">
+            <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+          </node>
+          <node concept="2OqwBi" id="hyutXZU" role="33vP2m">
+            <node concept="1PxgMI" id="7BsoQawDcpd" role="2Oq$k0">
+              <property role="1BlNFB" value="true" />
+              <node concept="chp4Y" id="7BsoQawDcpF" role="3oSUPX">
+                <ref role="cht4Q" to="tpee:hqOqwz4" resolve="DotExpression" />
+              </node>
+              <node concept="2OqwBi" id="hxx$G8U" role="1m5AlR">
+                <node concept="1YBJjd" id="7BsoQawDbr1" role="2Oq$k0">
+                  <ref role="1YBMHb" node="7BsoQawDanB" resolve="op" />
+                </node>
+                <node concept="1mfA1w" id="hfqC40a" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3TrEf2" id="hyutYPq" role="2OqNvi">
+              <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="hfugf8O" role="3cqZAp">
+        <node concept="3clFbS" id="hfugf8P" role="3clFbx">
+          <node concept="1ZxtTE" id="hfugf8Q" role="3cqZAp">
+            <property role="TrG5h" value="elementType" />
+          </node>
+          <node concept="1ZxtTE" id="7BsoQawDcVP" role="3cqZAp">
+            <property role="TrG5h" value="leftType" />
+          </node>
+          <node concept="1ZxtTE" id="7BsoQawDcVT" role="3cqZAp">
+            <property role="TrG5h" value="rightType" />
+          </node>
+          <node concept="1ZoDhX" id="1cMKCH9ScVw" role="3cqZAp">
+            <property role="3wDh2S" value="false" />
+            <node concept="mw_s8" id="hgnxd4a" role="1ZfhKB">
+              <node concept="1Z2H0r" id="hfugf8X" role="mwGJk">
+                <node concept="37vLTw" id="3GM_nagTt6d" role="1Z2MuG">
+                  <ref role="3cqZAo" node="hfqCrgr" resolve="input" />
+                </node>
+              </node>
+            </node>
+            <node concept="mw_s8" id="hgnxd4b" role="1ZfhK$">
+              <node concept="2c44tf" id="hq_xC_3" role="mwGJk">
+                <node concept="A3Dl8" id="hq_xC_4" role="2c44tc">
+                  <node concept="33vP2l" id="hq_xC_5" role="A3Ik2">
+                    <node concept="2c44te" id="hq_xC_8" role="lGtFl">
+                      <node concept="1Z$b5t" id="hq_xC_9" role="2c44t1">
+                        <ref role="1Z$eMM" node="hfugf8Q" resolve="elementType" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1ZobV4" id="7BsoQawDcUL" role="3cqZAp">
+            <node concept="mw_s8" id="7BsoQawDcUQ" role="1ZfhK$">
+              <node concept="1Z$b5t" id="7BsoQawDcUO" role="mwGJk">
+                <ref role="1Z$eMM" node="hfugf8Q" resolve="elementType" />
+              </node>
+            </node>
+            <node concept="mw_s8" id="7BsoQawDcV1" role="1ZfhKB">
+              <node concept="2c44tf" id="7BsoQawDcUX" role="mwGJk">
+                <node concept="1LlUBW" id="7BsoQawDcVl" role="2c44tc">
+                  <node concept="10P_77" id="7BsoQawDdhY" role="1Lm7xW">
+                    <node concept="2c44te" id="7BsoQawDdpy" role="lGtFl">
+                      <node concept="1Z$b5t" id="7BsoQawDdpE" role="2c44t1">
+                        <ref role="1Z$eMM" node="7BsoQawDcVP" resolve="leftType" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="10P_77" id="7BsoQawDdpm" role="1Lm7xW">
+                    <node concept="2c44te" id="7BsoQawDdrp" role="lGtFl">
+                      <node concept="1Z$b5t" id="7BsoQawDdrx" role="2c44t1">
+                        <ref role="1Z$eMM" node="7BsoQawDcVT" resolve="rightType" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1Z5TYs" id="hfugf8Z" role="3cqZAp">
+            <node concept="mw_s8" id="hgnxd4d" role="1ZfhKB">
+              <node concept="2c44tf" id="7BsoQawDdrW" role="mwGJk">
+                <node concept="3rvAFt" id="7BsoQawDdsv" role="2c44tc">
+                  <node concept="10P_77" id="7BsoQawDdRj" role="3rvQeY">
+                    <node concept="2c44te" id="7BsoQawDe5u" role="lGtFl">
+                      <node concept="1Z$b5t" id="7BsoQawDe5A" role="2c44t1">
+                        <ref role="1Z$eMM" node="7BsoQawDcVP" resolve="leftType" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="_YKpA" id="7BsoQawDe0s" role="3rvSg0">
+                    <node concept="10P_77" id="7BsoQawDe5d" role="_ZDj9">
+                      <node concept="2c44te" id="7BsoQawDe5f" role="lGtFl">
+                        <node concept="1Z$b5t" id="7BsoQawDe5n" role="2c44t1">
+                          <ref role="1Z$eMM" node="7BsoQawDcVT" resolve="rightType" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="mw_s8" id="hgnxd4c" role="1ZfhK$">
+              <node concept="1Z2H0r" id="hfugf95" role="mwGJk">
+                <node concept="1YBJjd" id="7BsoQawDc2F" role="1Z2MuG">
+                  <ref role="1YBMHb" node="7BsoQawDanB" resolve="op" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="hxx$Qk_" role="3clFbw">
+          <node concept="37vLTw" id="3GM_nagTrRg" role="2Oq$k0">
+            <ref role="3cqZAo" node="hfqCrgr" resolve="input" />
+          </node>
+          <node concept="3x8VRR" id="hfugf98" role="2OqNvi" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="7BsoQawDbLz" role="3cqZAp" />
+    </node>
+    <node concept="1YaCAy" id="7BsoQawDanB" role="1YuTPh">
+      <property role="TrG5h" value="op" />
+      <ref role="1YaFvo" to="pkab:7BsoQawD7eZ" resolve="ToMapOperation" />
     </node>
   </node>
 </model>

--- a/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.toMapOperation@tests.mps
+++ b/code/solutions/de.itemis.mps.baseLanguageExtensions.test/models/de.itemis.mps.baseLanguageExtensions.test.toMapOperation@tests.mps
@@ -1,0 +1,366 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:dc006d26-0874-4bb3-a1b1-d6effff96619(de.itemis.mps.baseLanguageExtensions.test.toMapOperation@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />
+  </languages>
+  <imports>
+    <import index="96gm" ref="r:2eaed950-3bc1-47cd-9b02-e917ff994d7c(de.itemis.mps.baseLanguageExtensions.runtime)" />
+  </imports>
+  <registry>
+    <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
+      <concept id="1238852151516" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleType" flags="in" index="1LlUBW">
+        <child id="1238852204892" name="componentType" index="1Lm7xW" />
+      </concept>
+      <concept id="1238853782547" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleLiteral" flags="nn" index="1Ls8ON">
+        <child id="1238853845806" name="component" index="1Lso8e" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171931690126" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethod" flags="ig" index="3s$Bmu">
+        <property id="1171931690128" name="methodName" index="3s$Bm0" />
+      </concept>
+      <concept id="1171931851043" name="jetbrains.mps.baseLanguage.unitTest.structure.BTestCase" flags="ig" index="3s_ewN">
+        <property id="1171931851045" name="testCaseName" index="3s_ewP" />
+        <child id="1171931851044" name="testMethodList" index="3s_ewO" />
+      </concept>
+      <concept id="1171931858461" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethodList" flags="ng" index="3s_gsd">
+        <child id="1171931858462" name="testMethod" index="3s_gse" />
+      </concept>
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="6126991172893676625" name="jetbrains.mps.baseLanguage.collections.structure.ContainsAllOperation" flags="nn" index="BjQpj" />
+      <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1201872418428" name="jetbrains.mps.baseLanguage.collections.structure.GetKeysOperation" flags="nn" index="3lbrtF" />
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
+        <child id="1197683466920" name="keyType" index="3rvQeY" />
+        <child id="1197683475734" name="valueType" index="3rvSg0" />
+      </concept>
+      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
+        <child id="1197687026896" name="keyType" index="3rHrn6" />
+        <child id="1197687035757" name="valueType" index="3rHtpV" />
+        <child id="1206655950512" name="initializer" index="3Mj9YC" />
+      </concept>
+      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
+        <child id="1197932505799" name="map" index="3ElQJh" />
+        <child id="1197932525128" name="key" index="3ElVtu" />
+      </concept>
+      <concept id="1206655653991" name="jetbrains.mps.baseLanguage.collections.structure.MapInitializer" flags="ng" index="3Mi1_Z">
+        <child id="1206655902276" name="entries" index="3MiYds" />
+      </concept>
+      <concept id="1206655735055" name="jetbrains.mps.baseLanguage.collections.structure.MapEntry" flags="ng" index="3Milgn">
+        <child id="1206655844556" name="key" index="3MiK7k" />
+        <child id="1206655853135" name="value" index="3MiMdn" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="3s_ewN" id="7BsoQawAjLT">
+    <property role="3s_ewP" value="ToMapOperationUtil" />
+    <node concept="3Tm1VV" id="7BsoQawAjLU" role="1B3o_S" />
+    <node concept="3s_gsd" id="7BsoQawAjLV" role="3s_ewO">
+      <node concept="3s$Bmu" id="7BsoQawAjMM" role="3s_gse">
+        <property role="3s$Bm0" value="testConvertingSeqOfPairsToMap" />
+        <node concept="3cqZAl" id="7BsoQawAjMN" role="3clF45" />
+        <node concept="3Tm1VV" id="7BsoQawAjMO" role="1B3o_S" />
+        <node concept="3clFbS" id="7BsoQawAjMP" role="3clF47">
+          <node concept="3cpWs8" id="7BsoQawAn5z" role="3cqZAp">
+            <node concept="3cpWsn" id="7BsoQawAn5$" role="3cpWs9">
+              <property role="TrG5h" value="seqOfPairs" />
+              <node concept="_YKpA" id="7BsoQawAn1s" role="1tU5fm">
+                <node concept="1LlUBW" id="7BsoQawAn1B" role="_ZDj9">
+                  <node concept="17QB3L" id="7BsoQawAn1C" role="1Lm7xW" />
+                  <node concept="10Oyi0" id="7BsoQawAn1D" role="1Lm7xW" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="7BsoQawAn5_" role="33vP2m">
+                <node concept="Tc6Ow" id="7BsoQawAn5A" role="2ShVmc">
+                  <node concept="1LlUBW" id="7BsoQawAn5B" role="HW$YZ">
+                    <node concept="17QB3L" id="7BsoQawAn5C" role="1Lm7xW" />
+                    <node concept="10Oyi0" id="7BsoQawAn5D" role="1Lm7xW" />
+                  </node>
+                  <node concept="1Ls8ON" id="7BsoQawAn5E" role="HW$Y0">
+                    <node concept="Xl_RD" id="7BsoQawAn5F" role="1Lso8e">
+                      <property role="Xl_RC" value="test" />
+                    </node>
+                    <node concept="3cmrfG" id="7BsoQawAn5G" role="1Lso8e">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                  </node>
+                  <node concept="1Ls8ON" id="7BsoQawAn5H" role="HW$Y0">
+                    <node concept="Xl_RD" id="7BsoQawAn5I" role="1Lso8e">
+                      <property role="Xl_RC" value="test" />
+                    </node>
+                    <node concept="3cmrfG" id="7BsoQawAn5J" role="1Lso8e">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                  </node>
+                  <node concept="1Ls8ON" id="7BsoQawAn5K" role="HW$Y0">
+                    <node concept="Xl_RD" id="7BsoQawAn5L" role="1Lso8e">
+                      <property role="Xl_RC" value="test" />
+                    </node>
+                    <node concept="3cmrfG" id="7BsoQawAn5M" role="1Lso8e">
+                      <property role="3cmrfH" value="3" />
+                    </node>
+                  </node>
+                  <node concept="1Ls8ON" id="7BsoQawAn5N" role="HW$Y0">
+                    <node concept="Xl_RD" id="7BsoQawAn5O" role="1Lso8e">
+                      <property role="Xl_RC" value="test1" />
+                    </node>
+                    <node concept="3cmrfG" id="7BsoQawAn5P" role="1Lso8e">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="7BsoQawAn$O" role="3cqZAp">
+            <node concept="3cpWsn" id="7BsoQawAn$P" role="3cpWs9">
+              <property role="TrG5h" value="actual" />
+              <node concept="3rvAFt" id="7BsoQawAnzG" role="1tU5fm">
+                <node concept="17QB3L" id="7BsoQawAnzR" role="3rvQeY" />
+                <node concept="_YKpA" id="7BsoQawAnzP" role="3rvSg0">
+                  <node concept="10Oyi0" id="7BsoQawAnzQ" role="_ZDj9" />
+                </node>
+              </node>
+              <node concept="2YIFZM" id="7BsoQawAn$Q" role="33vP2m">
+                <ref role="37wK5l" to="96gm:7BsoQawA4c5" resolve="toMap" />
+                <ref role="1Pybhc" to="96gm:7BsoQawA4aD" resolve="ToMapOperationUtil" />
+                <node concept="37vLTw" id="7BsoQawAn$R" role="37wK5m">
+                  <ref role="3cqZAo" node="7BsoQawAn5$" resolve="seqOfPairs" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="7BsoQawAt6H" role="3cqZAp">
+            <node concept="3cpWsn" id="7BsoQawAt6I" role="3cpWs9">
+              <property role="TrG5h" value="expected" />
+              <node concept="3rvAFt" id="7BsoQawAp5J" role="1tU5fm">
+                <node concept="17QB3L" id="7BsoQawAp5S" role="3rvQeY" />
+                <node concept="_YKpA" id="7BsoQawAp5T" role="3rvSg0">
+                  <node concept="10Oyi0" id="7BsoQawAp5U" role="_ZDj9" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="7BsoQawAt6J" role="33vP2m">
+                <node concept="3rGOSV" id="7BsoQawAt6K" role="2ShVmc">
+                  <node concept="17QB3L" id="7BsoQawAt6L" role="3rHrn6" />
+                  <node concept="_YKpA" id="7BsoQawAt6M" role="3rHtpV">
+                    <node concept="10Oyi0" id="7BsoQawAt6N" role="_ZDj9" />
+                  </node>
+                  <node concept="3Mi1_Z" id="7BsoQawAt6O" role="3Mj9YC">
+                    <node concept="3Milgn" id="7BsoQawAt6P" role="3MiYds">
+                      <node concept="Xl_RD" id="7BsoQawAt6Q" role="3MiK7k">
+                        <property role="Xl_RC" value="test" />
+                      </node>
+                      <node concept="2ShNRf" id="7BsoQawAt6R" role="3MiMdn">
+                        <node concept="Tc6Ow" id="7BsoQawAt6S" role="2ShVmc">
+                          <node concept="10Oyi0" id="7BsoQawAt6T" role="HW$YZ" />
+                          <node concept="3cmrfG" id="7BsoQawAt6U" role="HW$Y0">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                          <node concept="3cmrfG" id="7BsoQawAt6V" role="HW$Y0">
+                            <property role="3cmrfH" value="2" />
+                          </node>
+                          <node concept="3cmrfG" id="7BsoQawAt6W" role="HW$Y0">
+                            <property role="3cmrfH" value="3" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3Milgn" id="7BsoQawAt6X" role="3MiYds">
+                      <node concept="Xl_RD" id="7BsoQawAt6Y" role="3MiK7k">
+                        <property role="Xl_RC" value="test1" />
+                      </node>
+                      <node concept="2ShNRf" id="7BsoQawAt6Z" role="3MiMdn">
+                        <node concept="Tc6Ow" id="7BsoQawAt70" role="2ShVmc">
+                          <node concept="10Oyi0" id="7BsoQawAt71" role="HW$YZ" />
+                          <node concept="3cmrfG" id="7BsoQawAt72" role="HW$Y0">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3vwNmj" id="7BsoQawAtAl" role="3cqZAp">
+            <node concept="17R0WA" id="7BsoQawAyhA" role="3vwVQn">
+              <node concept="2OqwBi" id="7BsoQawA$rc" role="3uHU7w">
+                <node concept="2OqwBi" id="7BsoQawAyZ2" role="2Oq$k0">
+                  <node concept="37vLTw" id="7BsoQawAyoe" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7BsoQawAt6I" resolve="expected" />
+                  </node>
+                  <node concept="3lbrtF" id="7BsoQawAzsb" role="2OqNvi" />
+                </node>
+                <node concept="34oBXx" id="7BsoQawA_3p" role="2OqNvi" />
+              </node>
+              <node concept="2OqwBi" id="7BsoQawAv9Q" role="3uHU7B">
+                <node concept="2OqwBi" id="7BsoQawAu2_" role="2Oq$k0">
+                  <node concept="37vLTw" id="7BsoQawAtGf" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7BsoQawAn$P" resolve="actual" />
+                  </node>
+                  <node concept="3lbrtF" id="7BsoQawAuug" role="2OqNvi" />
+                </node>
+                <node concept="34oBXx" id="7BsoQawAw4U" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3vwNmj" id="7BsoQawA_sr" role="3cqZAp">
+            <node concept="2OqwBi" id="7BsoQawABkN" role="3vwVQn">
+              <node concept="2OqwBi" id="7BsoQawA_Y_" role="2Oq$k0">
+                <node concept="37vLTw" id="7BsoQawA__i" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7BsoQawAn$P" resolve="actual" />
+                </node>
+                <node concept="3lbrtF" id="7BsoQawAAtd" role="2OqNvi" />
+              </node>
+              <node concept="BjQpj" id="7BsoQawABYr" role="2OqNvi">
+                <node concept="2OqwBi" id="7BsoQawACAX" role="25WWJ7">
+                  <node concept="37vLTw" id="7BsoQawAC8u" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7BsoQawAt6I" resolve="expected" />
+                  </node>
+                  <node concept="3lbrtF" id="7BsoQawACTH" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3vwNmj" id="7BsoQawADfq" role="3cqZAp">
+            <node concept="2OqwBi" id="7BsoQawAEdx" role="3vwVQn">
+              <node concept="2OqwBi" id="7BsoQawADA2" role="2Oq$k0">
+                <node concept="37vLTw" id="7BsoQawADqS" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7BsoQawAt6I" resolve="expected" />
+                </node>
+                <node concept="3lbrtF" id="7BsoQawADTE" role="2OqNvi" />
+              </node>
+              <node concept="2HxqBE" id="7BsoQawAExk" role="2OqNvi">
+                <node concept="1bVj0M" id="7BsoQawAExm" role="23t8la">
+                  <node concept="3clFbS" id="7BsoQawAExn" role="1bW5cS">
+                    <node concept="3clFbF" id="7BsoQawAFmR" role="3cqZAp">
+                      <node concept="2OqwBi" id="7BsoQawAH0W" role="3clFbG">
+                        <node concept="3EllGN" id="7BsoQawAFLc" role="2Oq$k0">
+                          <node concept="37vLTw" id="7BsoQawAG8_" role="3ElVtu">
+                            <ref role="3cqZAo" node="7BsoQawAExo" resolve="eKey" />
+                          </node>
+                          <node concept="37vLTw" id="7BsoQawAFmQ" role="3ElQJh">
+                            <ref role="3cqZAo" node="7BsoQawAt6I" resolve="expected" />
+                          </node>
+                        </node>
+                        <node concept="BjQpj" id="7BsoQawAHV8" role="2OqNvi">
+                          <node concept="3EllGN" id="7BsoQawAIyV" role="25WWJ7">
+                            <node concept="37vLTw" id="7BsoQawAINB" role="3ElVtu">
+                              <ref role="3cqZAo" node="7BsoQawAExo" resolve="eKey" />
+                            </node>
+                            <node concept="37vLTw" id="7BsoQawAIbO" role="3ElQJh">
+                              <ref role="3cqZAo" node="7BsoQawAn$P" resolve="actual" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7BsoQawAExo" role="1bW2Oz">
+                    <property role="TrG5h" value="eKey" />
+                    <node concept="2jxLKc" id="7BsoQawAExp" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+


### PR DESCRIPTION
## Name
`toMap`

## Operation Type
Sequence operation.

## Use Case
The `toMap` operation can be used to convert a sequence of pairs of type `[K, V]` into a map of type `map<K, list<V>>`.

## Comments
Example of usage.
```java
> new arraylist<[string,int]>{
    ["test", 1], ["test", 2], ["test1", 3]
  }.toMap
  ["test"=[1, 2], "test1"=[3]]
```
